### PR TITLE
Simplify Onboarding Experience

### DIFF
--- a/app/api/sample-results/route.ts
+++ b/app/api/sample-results/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+
+const SAMPLE_RESULTS_URL = "https://monadic-dna-explorer.nyc3.cdn.digitaloceanspaces.com/monadic_dna_explorer_results_2026-05-19.tsv";
+
+export async function GET() {
+  try {
+    const upstream = await fetch(SAMPLE_RESULTS_URL, {
+      method: "GET",
+      cache: "no-store",
+    });
+
+    if (!upstream.ok) {
+      return NextResponse.json(
+        { error: `Sample results upstream failed with status ${upstream.status}` },
+        { status: 502 }
+      );
+    }
+
+    const data = await upstream.arrayBuffer();
+    const contentType = upstream.headers.get("content-type") || "text/tab-separated-values; charset=utf-8";
+    const contentLength = upstream.headers.get("content-length") || String(data.byteLength);
+
+    return new NextResponse(data, {
+      status: 200,
+      headers: {
+        "Content-Type": contentType,
+        "Content-Length": contentLength,
+        "Content-Disposition": "inline; filename=\"monadic_dna_explorer_results_2026-05-19.tsv\"",
+        "Cache-Control": "no-store",
+      },
+    });
+  } catch (error) {
+    console.error("[sample-results] Failed to fetch sample results:", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to fetch sample results" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/components/ConversionOnboarding.tsx
+++ b/app/components/ConversionOnboarding.tsx
@@ -1,3 +1,4 @@
+// MOTHBALLED 2026-05-19: The conversion onboarding flow is preserved for reference, but active entry points now use the lightweight new-user choice modal.
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -69,6 +69,25 @@ export default function Footer() {
             </a>
             . All rights reserved.
           </p>
+          <p className="footer-legal-links">
+            <a
+              href="https://github.com/Monadic-DNA/Explorer/blob/main/terms_and_conditions.md"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="footer-link"
+            >
+              Terms and Conditions
+            </a>
+            {" · "}
+            <a
+              href="https://github.com/Monadic-DNA/Explorer/blob/main/privacy_policy.md"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="footer-link"
+            >
+              Privacy Policy
+            </a>
+          </p>
         </div>
 
         <div className="footer-section">

--- a/app/components/LLMChatInline.tsx
+++ b/app/components/LLMChatInline.tsx
@@ -1083,9 +1083,9 @@ Remember: You have plenty of space. Use ALL of it to provide a complete, thoroug
                     )}
                     {customizationStatus === 'unlocked' ? (
                       <span className="rag-hint rag-hint-ok">Personalization on for more relevant results.</span>
-                    ) : customizationStatus !== 'loading' ? (
+                    ) : (
                       <span className="rag-hint">Personalization not set. Your demographic, family, and medical history will not be used for interpreting your results. Use Personalize up top for better answers.</span>
-                    ) : null}
+                    )}
                   </>
                 )}
               </div>

--- a/app/components/LLMChatInline.tsx
+++ b/app/components/LLMChatInline.tsx
@@ -501,6 +501,7 @@ RESPONSE STRUCTURE (Complete Each Section Fully):
 - Group findings into 2-4 major themes (e.g., cardiovascular, metabolic, inflammatory)
 - For each theme, explain the overall trend and what it means for them specifically
 - Connect how different themes relate to each other
+- Mention the most relevant gene/SNP/allele combinations, along with the associated OR or beta.
 
 **Section 3: What This Means for You Specifically** (2-3 paragraphs)
 - Synthesize how these findings interact with their ethnicity, age, and medical history
@@ -874,7 +875,8 @@ Remember: You have plenty of space. Use ALL of it to provide a complete, thoroug
           )}
 
           {messages
-            .filter(message => message.role !== 'system') // Hide system messages from UI
+            .filter(message => message.role !== 'system')
+            .filter(message => !(message.role === 'assistant' && !message.content && isLoading))
             .map((message, idx, filteredMessages) => {
               // Check if this is the last assistant message in the filtered array
               const isLastAssistantMessage = message.role === 'assistant' &&
@@ -896,31 +898,13 @@ Remember: You have plenty of space. Use ALL of it to provide a complete, thoroug
                   )}
                 </div>
                 {message.role === 'assistant' && (
-                  <>
-                    <button
-                      className="copy-button"
-                      onClick={() => handleCopyMessage(message.content)}
-                      title="Copy to clipboard"
-                    >
-                      Copy
-                    </button>
-                    {isLastAssistantMessage && !isLoading && (
-                      <div className="followup-suggestions">
-                        <div className="followup-header">Try asking:</div>
-                        <div className="followup-buttons">
-                          {FOLLOWUP_SUGGESTIONS.map((suggestion, sidx) => (
-                            <button
-                              key={sidx}
-                              className="followup-button"
-                              onClick={() => handleExampleClick(suggestion)}
-                            >
-                              {suggestion}
-                            </button>
-                          ))}
-                        </div>
-                      </div>
-                    )}
-                  </>
+                  <button
+                    className="copy-button"
+                    onClick={() => handleCopyMessage(message.content)}
+                    title="Copy to clipboard"
+                  >
+                    Copy
+                  </button>
                 )}
                 {message.role === 'assistant' && message.studiesUsed && message.studiesUsed.length > 0 && (
                   <div className="studies-used">
@@ -954,6 +938,22 @@ Remember: You have plenty of space. Use ALL of it to provide a complete, thoroug
                         ))}
                       </div>
                     )}
+                  </div>
+                )}
+                {message.role === 'assistant' && isLastAssistantMessage && !isLoading && (
+                  <div className="followup-suggestions">
+                    <div className="followup-header">Try asking:</div>
+                    <div className="followup-buttons">
+                      {FOLLOWUP_SUGGESTIONS.map((suggestion, sidx) => (
+                        <button
+                          key={sidx}
+                          className="followup-button"
+                          onClick={() => handleExampleClick(suggestion)}
+                        >
+                          {suggestion}
+                        </button>
+                      ))}
+                    </div>
                   </div>
                 )}
                 {message.role === 'user' && message.attachments && message.attachments.length > 0 && (
@@ -1090,8 +1090,13 @@ Remember: You have plenty of space. Use ALL of it to provide a complete, thoroug
                 )}
               </div>
             ) : (
-              <div className="rag-info-followup">
-                Follow-up question
+              <div className="chat-actions">
+                <button className="chat-action-button" onClick={handlePrintChat}>
+                  Print
+                </button>
+                <button className="chat-action-button" onClick={handleClearChat}>
+                  Clear
+                </button>
               </div>
             )}
             <div className="chat-buttons">

--- a/app/components/LLMChatInline.tsx
+++ b/app/components/LLMChatInline.tsx
@@ -8,8 +8,6 @@ import { useCustomization } from "./CustomizationContext";
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { callLLM, callLLMStream, getLLMDescription, MessageContentPart } from "@/lib/llm-client";
-import { getLLMConfig } from "@/lib/llm-config";
-import { SparklesIcon } from "./Icons";
 import { trackLLMQuestionAsked } from "@/lib/analytics";
 
 type AttachmentType = 'text' | 'pdf' | 'csv' | 'tsv' | 'image';
@@ -58,11 +56,7 @@ const FOLLOWUP_SUGGESTIONS = [
   "How should I adjust my diet and lifestyle?"
 ];
 
-type AIChatInlineProps = {
-  onOpenTour?: () => void;
-};
-
-export default function AIChatInline({ onOpenTour }: AIChatInlineProps = {}) {
+export default function AIChatInline() {
   const resultsContext = useResults();
   const { getTopResultsByRelevance } = resultsContext;
   const { customization, status: customizationStatus } = useCustomization();
@@ -74,12 +68,10 @@ export default function AIChatInline({ onOpenTour }: AIChatInlineProps = {}) {
   const [error, setError] = useState<string | null>(null);
   const [showConsentModal, setShowConsentModal] = useState(false);
   const [hasConsent, setHasConsent] = useState(false);
-  const [showPersonalizationPrompt, setShowPersonalizationPrompt] = useState(false);
   const [expandedMessageIndex, setExpandedMessageIndex] = useState<number | null>(null);
   const [attachedFiles, setAttachedFiles] = useState<File[]>([]);
   const [attachmentError, setAttachmentError] = useState<string | null>(null);
   const [expandedAttachmentIndex, setExpandedAttachmentIndex] = useState<number | null>(null);
-  const [showProviderTip, setShowProviderTip] = useState(true);
 
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -104,14 +96,6 @@ export default function AIChatInline({ onOpenTour }: AIChatInlineProps = {}) {
     }
   }, []);
 
-  useEffect(() => {
-    // Check if personalization is not set or locked on mount only
-    if (customizationStatus === 'not-set' || customizationStatus === 'locked') {
-      setShowPersonalizationPrompt(true);
-    } else if (customizationStatus === 'unlocked') {
-      setShowPersonalizationPrompt(false);
-    }
-  }, [customizationStatus]);
 
   // Removed auto-scroll so user doesn't have to scroll up to read responses
   // Also removed auto-focus to prevent scrolling to bottom on tab load
@@ -121,6 +105,7 @@ export default function AIChatInline({ onOpenTour }: AIChatInlineProps = {}) {
       localStorage.setItem(CONSENT_STORAGE_KEY, "true");
       setHasConsent(true);
       setShowConsentModal(false);
+      void handleSendMessage(true);
     }
   };
 
@@ -128,9 +113,6 @@ export default function AIChatInline({ onOpenTour }: AIChatInlineProps = {}) {
     setShowConsentModal(false);
   };
 
-  const handlePersonalizationPromptContinue = () => {
-    setShowPersonalizationPrompt(false);
-  };
 
   const handleExampleClick = (question: string) => {
     setInputValue(question);
@@ -153,32 +135,6 @@ export default function AIChatInline({ onOpenTour }: AIChatInlineProps = {}) {
       return `β=${score >= 0 ? '+' : ''}${score.toFixed(3)} units`;
     }
     return `${score.toFixed(2)}x`;
-  };
-
-  const getProviderTip = () => {
-    if (!mounted) return null;
-
-    const config = getLLMConfig();
-
-    if (config.provider === 'nilai' || config.provider === 'ollama') {
-      return {
-        icon: 'Private',
-        type: 'privacy',
-        message: config.provider === 'nilai'
-          ? 'nilAI is active for privacy-preserving TEE processing.'
-          : 'Ollama is active for local processing on your device.',
-        tip: 'Switch models from the LLM button in the menu bar.',
-      };
-    } else if (config.provider === 'huggingface') {
-      return {
-        icon: 'Fast',
-        type: 'performance',
-        message: 'HuggingFace is active for broader model access.',
-        tip: 'Switch back to nilAI from the LLM button for stronger privacy.',
-      };
-    }
-
-    return null;
   };
 
   const handleAttachmentClick = () => {
@@ -341,12 +297,12 @@ export default function AIChatInline({ onOpenTour }: AIChatInlineProps = {}) {
     return parts;
   };
 
-  const handleSendMessage = async () => {
+  const handleSendMessage = async (skipConsentCheck = false) => {
     const query = inputValue.trim();
     if (!query) return;
 
     // Check consent before sending first message
-    if (!hasConsent) {
+    if (!skipConsentCheck && !hasConsent) {
       setShowConsentModal(true);
       return;
     }
@@ -889,34 +845,8 @@ Remember: You have plenty of space. Use ALL of it to provide a complete, thoroug
         />
       )}
       <div className="ai-chat-inline" style={{ position: 'relative' }}>
-        <div className="chat-header">
-          <div className="dna-chat-header-main">
-            <div className="dna-chat-title-mark">
-              <SparklesIcon size={24} />
-            </div>
-            <div>
-              <h2>DNA Chat</h2>
-              <p className="powered-by">
-                {getLLMDescription()} - secure processing for your saved genetic results
-              </p>
-              {onOpenTour && (
-                <button
-                  type="button"
-                  className="dna-chat-inline-tour-link"
-                  onClick={onOpenTour}
-                >
-                  Take the tour
-                </button>
-              )}
-            </div>
-          </div>
-        </div>
-
-        <div className="chat-info">
-          <div className="chat-info-left">
-            <span>{mounted ? resultsContext.savedResults.length.toLocaleString() : '...'} saved genetic results available</span>
-          </div>
-          {messages.length > 0 && (
+        {messages.length > 0 && (
+          <div className="chat-info">
             <div className="chat-actions">
               <button className="chat-action-button" onClick={handlePrintChat}>
                 Print
@@ -925,66 +855,13 @@ Remember: You have plenty of space. Use ALL of it to provide a complete, thoroug
                 Clear
               </button>
             </div>
-          )}
-        </div>
-
-        {showPersonalizationPrompt && (
-          <div className="dna-chat-personalization-banner">
-            <div>
-              <strong>Personalization improves answers.</strong>
-              <span>
-                {customizationStatus === 'locked'
-                  ? ' Unlock your saved profile from the Personalize menu when you are ready.'
-                  : ' Add ancestry, history, and demographics from the Personalize menu when you are ready.'}
-              </span>
-            </div>
-            <button
-              type="button"
-              onClick={handlePersonalizationPromptContinue}
-              aria-label="Dismiss personalization recommendation"
-            >
-              Not now
-            </button>
           </div>
         )}
-
-        {/* Provider tip banner */}
-        {showProviderTip && (() => {
-          const tip = getProviderTip();
-          if (!tip) return null;
-
-          return (
-            <div className={`provider-tip ${tip.type}`}>
-              <div className="provider-tip-content">
-                <span className="provider-tip-icon">{tip.icon}</span>
-                <div className="provider-tip-text">
-                  <div className="provider-tip-message">{tip.message}</div>
-                  <div className="provider-tip-suggestion">{tip.tip}</div>
-                </div>
-              </div>
-              <button className="provider-tip-dismiss" onClick={() => setShowProviderTip(false)} title="Dismiss">
-                ×
-              </button>
-            </div>
-          );
-        })()}
 
         <div className="chat-messages">
           {messages.length === 0 && (
             <div className="chat-welcome">
-              <div className="chat-welcome-heading">
-                <h3>Ask about your DNA results</h3>
-                <span>Suggested prompts</span>
-              </div>
-
-              {mounted && resultsContext.savedResults.length < 1000 && (
-                <div className="chat-warning">
-                  <p><strong>Limited results ({resultsContext.savedResults.length} studies)</strong></p>
-                  <p>
-                    For better answers, analyze more studies or load a prior results file.
-                  </p>
-                </div>
-              )}
+              {}
 
               <ul className="example-questions">
                 {EXAMPLE_QUESTIONS.map((question) => (
@@ -993,9 +870,6 @@ Remember: You have plenty of space. Use ALL of it to provide a complete, thoroug
                   </li>
                 ))}
               </ul>
-              <div className="chat-disclaimer chat-disclaimer-inline">
-                <strong>Disclaimer:</strong> LLMs can report incorrect or fabricated information and are not medical experts. <strong>For educational purposes only.</strong> Consult a healthcare professional for medical advice.
-              </div>
             </div>
           )}
 
@@ -1198,7 +1072,22 @@ Remember: You have plenty of space. Use ALL of it to provide a complete, thoroug
           <div className="chat-input-controls">
             {isFirstMessage ? (
               <div className="rag-info">
-                Searches saved traits for context
+                {mounted && (
+                  <>
+                    {resultsContext.savedResults.length === 0 ? (
+                      <span className="rag-hint rag-hint-warn">No results loaded. Use My Data up top to load your data, then Run All to get your results.</span>
+                    ) : resultsContext.savedResults.length < 1000 ? (
+                      <span className="rag-hint rag-hint-warn">{resultsContext.savedResults.length.toLocaleString()} results loaded. For better answers, run more studies.</span>
+                    ) : (
+                      <span className="rag-hint">{resultsContext.savedResults.length.toLocaleString()} results available for analysis.</span>
+                    )}
+                    {customizationStatus === 'unlocked' ? (
+                      <span className="rag-hint rag-hint-ok">Personalization on for more relevant results.</span>
+                    ) : customizationStatus !== 'loading' ? (
+                      <span className="rag-hint">Personalization not set. Your demographic, family, and medical history will not be used for interpreting your results. Use Personalize up top for better answers.</span>
+                    ) : null}
+                  </>
+                )}
               </div>
             ) : (
               <div className="rag-info-followup">
@@ -1217,7 +1106,7 @@ Remember: You have plenty of space. Use ALL of it to provide a complete, thoroug
               </button>
               <button
                 className="chat-send-button"
-                onClick={handleSendMessage}
+                onClick={() => handleSendMessage()}
                 disabled={isLoading || !inputValue.trim()}
               >
                 {isLoading ? 'Sending...' : 'Send'}
@@ -1227,7 +1116,7 @@ Remember: You have plenty of space. Use ALL of it to provide a complete, thoroug
         </div>
 
         <div className="chat-footer-disclaimer">
-          AI-generated content may contain errors. This is not medical advice.
+          LLMs can report incorrect or fabricated information and are not medical experts. For educational purposes only. Consult a healthcare professional for medical advice.
         </div>
       </div>
     </>

--- a/app/components/LLMChatInline.tsx
+++ b/app/components/LLMChatInline.tsx
@@ -5,14 +5,12 @@ import { SavedResult } from "@/lib/results-manager";
 import NilAIConsentModal from "./NilAIConsentModal";
 import { useResults } from "./ResultsContext";
 import { useCustomization } from "./CustomizationContext";
-import { useAuth } from "./AuthProvider";
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { callLLM, callLLMStream, getLLMDescription, MessageContentPart } from "@/lib/llm-client";
 import { getLLMConfig } from "@/lib/llm-config";
 import { SparklesIcon } from "./Icons";
 import { trackLLMQuestionAsked } from "@/lib/analytics";
-import { hasValidPromoAccess } from "@/lib/promo-access";
 
 type AttachmentType = 'text' | 'pdf' | 'csv' | 'tsv' | 'image';
 
@@ -68,8 +66,6 @@ export default function AIChatInline({ onOpenTour }: AIChatInlineProps = {}) {
   const resultsContext = useResults();
   const { getTopResultsByRelevance } = resultsContext;
   const { customization, status: customizationStatus } = useCustomization();
-  const { hasActiveSubscription } = useAuth();
-
   const [mounted, setMounted] = useState(false);
   const [messages, setMessages] = useState<Message[]>([]);
   const [inputValue, setInputValue] = useState("");
@@ -78,7 +74,6 @@ export default function AIChatInline({ onOpenTour }: AIChatInlineProps = {}) {
   const [error, setError] = useState<string | null>(null);
   const [showConsentModal, setShowConsentModal] = useState(false);
   const [hasConsent, setHasConsent] = useState(false);
-  const [hasPromoAccess, setHasPromoAccess] = useState(false);
   const [showPersonalizationPrompt, setShowPersonalizationPrompt] = useState(false);
   const [expandedMessageIndex, setExpandedMessageIndex] = useState<number | null>(null);
   const [attachedFiles, setAttachedFiles] = useState<File[]>([]);
@@ -91,11 +86,6 @@ export default function AIChatInline({ onOpenTour }: AIChatInlineProps = {}) {
 
   useEffect(() => {
     setMounted(true);
-
-    // Check for promo code access
-    if (hasValidPromoAccess()) {
-      setHasPromoAccess(true);
-    }
 
     // Check consent
     const consent = localStorage.getItem(CONSENT_STORAGE_KEY);
@@ -354,25 +344,6 @@ export default function AIChatInline({ onOpenTour }: AIChatInlineProps = {}) {
   const handleSendMessage = async () => {
     const query = inputValue.trim();
     if (!query) return;
-
-    // Check authentication first
-    if (!hasActiveSubscription && !hasPromoAccess) {
-      // Check if user is authenticated
-      const dynamicButton = document.querySelector('[data-dynamic-widget-button]') as HTMLElement;
-      if (dynamicButton) {
-        // Try to determine if user is logged in by checking for Dynamic's user indicator
-        const isLoggedIn = document.querySelector('[data-dynamic-user-profile]');
-        if (!isLoggedIn) {
-          // Not logged in, trigger login
-          dynamicButton.click();
-          return;
-        }
-      }
-      // User is logged in but not subscribed, show payment modal
-      const event = new CustomEvent('openPaymentModal');
-      window.dispatchEvent(event);
-      return;
-    }
 
     // Check consent before sending first message
     if (!hasConsent) {
@@ -1248,9 +1219,8 @@ Remember: You have plenty of space. Use ALL of it to provide a complete, thoroug
                 className="chat-send-button"
                 onClick={handleSendMessage}
                 disabled={isLoading || !inputValue.trim()}
-                title={(!hasActiveSubscription && !hasPromoAccess) ? 'Login and subscribe to send messages' : undefined}
               >
-                {isLoading ? 'Sending...' : (!hasActiveSubscription && !hasPromoAccess) ? 'Login/Subscribe' : 'Send'}
+                {isLoading ? 'Sending...' : 'Send'}
               </button>
             </div>
           </div>

--- a/app/components/MenuBar.tsx
+++ b/app/components/MenuBar.tsx
@@ -358,9 +358,9 @@ export default function MenuBar() {
         isOpen={showHelpDropdown}
         onClose={() => setShowHelpDropdown(false)}
         onRestartOnboarding={() => {
-          trackGetStartedClicked("restart_onboarding");
+          trackGetStartedClicked("welcome_options");
           if (pathname === "/") {
-            window.dispatchEvent(new CustomEvent("openConversionOnboarding", { detail: { mode: "guided" } }));
+            window.dispatchEvent(new CustomEvent("openNewUserChoiceModal"));
             return;
           }
 
@@ -410,13 +410,10 @@ export default function MenuBar() {
           </Link>
           <Link
             href="/dna-chat"
-            className={isDNAChatActive ? "nav-link active nav-premium-link" : "nav-link nav-premium-link"}
+            className={isDNAChatActive ? "nav-link active" : "nav-link"}
             style={getNavLinkStyle(isDNAChatActive)}
           >
-            <span className="nav-link-content">
-              DNA Chat
-              <span className="nav-premium-badge">Premium</span>
-            </span>
+            DNA Chat
           </Link>
           <Link
             href="/overview-report"
@@ -522,7 +519,7 @@ export default function MenuBar() {
           <button
             className="menu-icon-button"
             onClick={() => setShowHelpDropdown(!showHelpDropdown)}
-            title="Get help and reopen onboarding"
+            title="Get help and start options"
             data-tour="help-button"
           >
             <span className="icon">

--- a/app/components/MenuBar.tsx
+++ b/app/components/MenuBar.tsx
@@ -172,6 +172,8 @@ export default function MenuBar() {
   };
 
   const handleRunAll = () => {
+    window.dispatchEvent(new Event("showMobileCompatibilityNotice"));
+
     if (isRunningAll) {
       setShowRunAllModal(true);
       return;

--- a/app/components/MenuDropdowns.tsx
+++ b/app/components/MenuDropdowns.tsx
@@ -328,9 +328,9 @@ export function HelpDropdown({
                 onRestartOnboarding();
                 onClose();
               }}
-              title="Open the new onboarding flow again"
+              title="Open start options"
             >
-              ↺ Restart Onboarding
+              Start Options
             </button>
           )}
           <a

--- a/app/components/MenuDropdowns.tsx
+++ b/app/components/MenuDropdowns.tsx
@@ -321,18 +321,6 @@ export function HelpDropdown({
       <div className="dropdown-content">
         <h3>Help & Feedback</h3>
         <div className="dropdown-actions">
-          {onRestartOnboarding && (
-            <button
-              className="control-button"
-              onClick={() => {
-                onRestartOnboarding();
-                onClose();
-              }}
-              title="Open start options"
-            >
-              Start Options
-            </button>
-          )}
           <a
             href="mailto:support@monadicdna.com"
             className="control-button"

--- a/app/components/MobileCompatibilityNotice.tsx
+++ b/app/components/MobileCompatibilityNotice.tsx
@@ -10,22 +10,16 @@ export default function MobileCompatibilityNotice() {
   const noticeRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const dismissed = localStorage.getItem(STORAGE_KEY) === "true";
-    const mediaQuery = window.matchMedia(MOBILE_QUERY);
-
-    const updateVisibility = () => {
-      setShouldShow(mediaQuery.matches && !dismissed);
+    const handleTrigger = () => {
+      const dismissed = localStorage.getItem(STORAGE_KEY) === "true";
+      const isMobile = window.matchMedia(MOBILE_QUERY).matches;
+      if (isMobile && !dismissed) {
+        setShouldShow(true);
+      }
     };
 
-    updateVisibility();
-
-    if (mediaQuery.addEventListener) {
-      mediaQuery.addEventListener("change", updateVisibility);
-      return () => mediaQuery.removeEventListener("change", updateVisibility);
-    }
-
-    mediaQuery.addListener(updateVisibility);
-    return () => mediaQuery.removeListener(updateVisibility);
+    window.addEventListener("showMobileCompatibilityNotice", handleTrigger);
+    return () => window.removeEventListener("showMobileCompatibilityNotice", handleTrigger);
   }, []);
 
   useEffect(() => {

--- a/app/components/PremiumFeatureHeader.tsx
+++ b/app/components/PremiumFeatureHeader.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { AuthButton, useAuth } from "./AuthProvider";
 import { clearPromoAccess, hasValidPromoAccess } from "@/lib/promo-access";
-import { trackPremiumTabViewed } from "@/lib/analytics";
+import { trackOverviewReportTabViewed } from "@/lib/analytics";
 
 type PremiumFeatureHeaderProps = {
   featureName: string;
@@ -51,7 +51,7 @@ export default function PremiumFeatureHeader({
   useEffect(() => {
     if (tabViewTrackedRef.current) return;
     tabViewTrackedRef.current = true;
-    trackPremiumTabViewed(featureName.toLowerCase().replace(/\s+/g, "_"), hasPremiumAccess);
+    trackOverviewReportTabViewed(hasPremiumAccess);
   }, [featureName, hasPremiumAccess]);
 
   return (

--- a/app/components/tours/tourContent.ts
+++ b/app/components/tours/tourContent.ts
@@ -17,7 +17,7 @@ export type TourContent = {
 const myDataStep: TourStep = {
   name: "my_data",
   title: "Upload your DNA first",
-  body: "If you haven't already, click 'My Data' in the top bar to upload your raw genetic data file from 23andMe, AncestryDNA, or similar. Your data is processed entirely in your browser and never sent to any server.",
+  body: "Click on 'My Data' in the top bar to upload your raw genetic data file from 23andMe, AncestryDNA, or similar. Your data is processed entirely in your browser and never sent to any server.",
   selector: '[data-tour="my-data-button"]',
   placement: "bottom",
 };
@@ -70,7 +70,7 @@ export const dnaChatTour: TourContent = {
     {
       name: "intro",
       title: "Chat with your DNA",
-      body: "DNA Chat is a private LLM that uses your saved genetic results as context. Ask anything about your traits, sleep, diet, or risks.",
+      body: "DNA Chat is an anonymous and confidential LLM chat that uses your genetic results as context. Ask anything about your traits, sleep, diet, or risks.",
     },
     myDataStep,
     {
@@ -90,14 +90,14 @@ export const dnaChatTour: TourContent = {
     {
       name: "send",
       title: "Send your question",
-      body: "Click here to send. The first answer pulls in your most relevant studies as context — follow-ups continue the conversation.",
+      body: "Click here to send. The first answer pulls in your most relevant results as context and follow-ups continue the conversation.",
       selector: ".chat-send-button",
       placement: "top",
     },
     {
       name: "attach",
       title: "Upload lab reports and documents",
-      body: "You can attach PDFs, CSVs, or text files — like genetic lab reports or bloodwork — and ask questions about them directly. Come back every time you have a new document to analyse.",
+      body: "You can attach PDFs, CSVs, or text files, like lab reports or medical notes, and ask questions about them directly. Come back every time you have a new document to analyse.",
       selector: '[data-tour="attach-button"]',
       placement: "top",
     },

--- a/app/dna-chat/page.tsx
+++ b/app/dna-chat/page.tsx
@@ -159,15 +159,6 @@ export default function DNAChatPage() {
     <div className="app-container">
       <MenuBar />
       <main className="page premium-feature-page dna-chat-page">
-        <section className="premium-compact-header dna-chat-open-header">
-          <div className="premium-header-content">
-            <div className="subscription-message">
-              <strong>DNA Chat is open to try</strong>
-              <span>Ask private questions about saved genetic results.</span>
-            </div>
-          </div>
-        </section>
-
         <section className="premium-section premium-feature-section dna-chat-section">
           {(sampleLoad.status === "downloading" || sampleLoad.status === "loading") && (
             <div className="dna-chat-sample-notice loading">
@@ -190,25 +181,17 @@ export default function DNAChatPage() {
           {sampleLoad.status === "loaded" && (
             <div className="dna-chat-sample-notice ready">
               <div>
-                <strong>Sample results are loaded.</strong>
-                <span>
-                  DNA Chat is using {sampleLoad.resultCount.toLocaleString()} sample results. You can upload your own DNA from My Data, then analyze it in Explore.
-                </span>
+                <strong>Sample data loaded.</strong>
+                <span>Using {sampleLoad.resultCount.toLocaleString()} sample results. To use your own DNA, click My Data, upload your file, then click Run All.</span>
               </div>
-              <button
-                type="button"
-                onClick={() => window.dispatchEvent(new CustomEvent("triggerDNAUpload"))}
-              >
-                Upload my data
-              </button>
             </div>
           )}
 
           {sampleLoad.status === "skipped" && (
             <div className="dna-chat-sample-notice ready">
               <div>
-                <strong>Your existing results are loaded.</strong>
-                <span>DNA Chat will use the results already in this browser session.</span>
+                <strong>Your results are loaded.</strong>
+                <span>DNA Chat will use the results in this browser session.</span>
               </div>
             </div>
           )}
@@ -222,7 +205,7 @@ export default function DNAChatPage() {
             </div>
           )}
 
-          <LLMChatInline onOpenTour={() => setTourOpen(true)} />
+          <LLMChatInline />
         </section>
       </main>
       <Footer />

--- a/app/dna-chat/page.tsx
+++ b/app/dna-chat/page.tsx
@@ -1,17 +1,44 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import MenuBar from "../components/MenuBar";
 import Footer from "../components/Footer";
-import PremiumFeatureHeader from "../components/PremiumFeatureHeader";
-import { PremiumPaywall } from "../components/PremiumPaywall";
 import LLMChatInline from "../components/LLMChatInline";
 import GuidedTour, { hasCompletedTour } from "../components/GuidedTour";
 import { dnaChatTour } from "../components/tours/tourContent";
+import { useResults } from "../components/ResultsContext";
+import { ResultsManager } from "@/lib/results-manager";
 import { trackDNAChatViewed } from "@/lib/analytics";
 
+const SAMPLE_RESULTS_FILE_NAME = "monadic_dna_explorer_results_2026-05-19.tsv";
+
+type SampleLoadState = {
+  status: "idle" | "downloading" | "loading" | "loaded" | "skipped" | "error";
+  downloadedBytes: number;
+  totalBytes: number;
+  resultCount: number;
+  error: string | null;
+};
+
+const initialSampleLoadState: SampleLoadState = {
+  status: "idle",
+  downloadedBytes: 0,
+  totalBytes: 0,
+  resultCount: 0,
+  error: null,
+};
+
+function formatBytes(bytes: number): string {
+  if (!bytes) return "0 KB";
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
 export default function DNAChatPage() {
+  const { addResultsBatch, clearResults, savedResults } = useResults();
   const [tourOpen, setTourOpen] = useState(false);
+  const [sampleLoad, setSampleLoad] = useState<SampleLoadState>(initialSampleLoadState);
+  const sampleLoadStartedRef = useRef(false);
 
   useEffect(() => {
     trackDNAChatViewed();
@@ -23,17 +50,178 @@ export default function DNAChatPage() {
     }
   }, []);
 
+  useEffect(() => {
+    if (typeof window === "undefined" || sampleLoadStartedRef.current) return;
+
+    const url = new URL(window.location.href);
+    const shouldLoadSample = url.searchParams.get("sample") === "1";
+
+    if (!shouldLoadSample) return;
+
+    sampleLoadStartedRef.current = true;
+    url.searchParams.delete("sample");
+    window.history.replaceState({}, "", url.toString());
+
+    const loadSampleResults = async () => {
+      if (savedResults.length > 0) {
+        setSampleLoad({
+          status: "skipped",
+          downloadedBytes: 0,
+          totalBytes: 0,
+          resultCount: savedResults.length,
+          error: null,
+        });
+        return;
+      }
+
+      try {
+        setSampleLoad({ ...initialSampleLoadState, status: "downloading" });
+
+        const response = await fetch("/api/sample-results", { method: "GET" });
+        if (!response.ok) {
+          throw new Error(`Sample results download failed with status ${response.status}.`);
+        }
+
+        const totalBytes = Number(response.headers.get("content-length") || "0");
+        const decoder = new TextDecoder();
+        let content = "";
+        let downloadedBytes = 0;
+
+        if (response.body) {
+          const reader = response.body.getReader();
+
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            if (!value) continue;
+
+            downloadedBytes += value.byteLength;
+            content += decoder.decode(value, { stream: true });
+            setSampleLoad({
+              status: "downloading",
+              downloadedBytes,
+              totalBytes,
+              resultCount: 0,
+              error: null,
+            });
+          }
+
+          content += decoder.decode();
+        } else {
+          content = await response.text();
+          downloadedBytes = new Blob([content]).size;
+        }
+
+        setSampleLoad({
+          status: "loading",
+          downloadedBytes,
+          totalBytes: totalBytes || downloadedBytes,
+          resultCount: 0,
+          error: null,
+        });
+
+        const session = ResultsManager.parseResultsFile(content, SAMPLE_RESULTS_FILE_NAME);
+        if (!session.results.length) {
+          throw new Error("The sample results file did not contain any usable results.");
+        }
+
+        await clearResults();
+        await addResultsBatch(session.results);
+        localStorage.setItem("dna_chat_sample_results_loaded", "true");
+
+        setSampleLoad({
+          status: "loaded",
+          downloadedBytes,
+          totalBytes: totalBytes || downloadedBytes,
+          resultCount: session.results.length,
+          error: null,
+        });
+      } catch (error) {
+        console.error("[DNA Chat] Sample results load failed:", error);
+        setSampleLoad({
+          status: "error",
+          downloadedBytes: 0,
+          totalBytes: 0,
+          resultCount: 0,
+          error: error instanceof Error ? error.message : "Sample results could not be loaded.",
+        });
+      }
+    };
+
+    void loadSampleResults();
+  }, [addResultsBatch, clearResults, savedResults.length]);
+
+  const sampleProgress = sampleLoad.totalBytes > 0
+    ? Math.min(100, Math.round((sampleLoad.downloadedBytes / sampleLoad.totalBytes) * 100))
+    : 0;
+
   return (
     <div className="app-container">
       <MenuBar />
       <main className="page premium-feature-page dna-chat-page">
-        <PremiumFeatureHeader
-          featureName="DNA Chat"
-          description="Ask private questions about your saved genetic results."
-        />
-        <PremiumPaywall>{null}</PremiumPaywall>
+        <section className="premium-compact-header dna-chat-open-header">
+          <div className="premium-header-content">
+            <div className="subscription-message">
+              <strong>DNA Chat is open to try</strong>
+              <span>Ask private questions about saved genetic results.</span>
+            </div>
+          </div>
+        </section>
 
         <section className="premium-section premium-feature-section dna-chat-section">
+          {(sampleLoad.status === "downloading" || sampleLoad.status === "loading") && (
+            <div className="dna-chat-sample-notice loading">
+              <div>
+                <strong>{sampleLoad.status === "downloading" ? "Downloading sample results" : "Loading sample results"}</strong>
+                <span>
+                  {sampleLoad.status === "downloading"
+                    ? sampleLoad.totalBytes > 0
+                      ? `${sampleProgress}% downloaded, ${formatBytes(sampleLoad.downloadedBytes)} of ${formatBytes(sampleLoad.totalBytes)}`
+                      : `${formatBytes(sampleLoad.downloadedBytes)} downloaded`
+                    : "Preparing the sample results for DNA Chat."}
+                </span>
+              </div>
+              <div className="wire-progress-bar">
+                <span style={{ width: `${sampleLoad.status === "loading" ? 100 : sampleProgress}%` }} />
+              </div>
+            </div>
+          )}
+
+          {sampleLoad.status === "loaded" && (
+            <div className="dna-chat-sample-notice ready">
+              <div>
+                <strong>Sample results are loaded.</strong>
+                <span>
+                  DNA Chat is using {sampleLoad.resultCount.toLocaleString()} sample results. You can upload your own DNA from My Data, then analyze it in Explore.
+                </span>
+              </div>
+              <button
+                type="button"
+                onClick={() => window.dispatchEvent(new CustomEvent("triggerDNAUpload"))}
+              >
+                Upload my data
+              </button>
+            </div>
+          )}
+
+          {sampleLoad.status === "skipped" && (
+            <div className="dna-chat-sample-notice ready">
+              <div>
+                <strong>Your existing results are loaded.</strong>
+                <span>DNA Chat will use the results already in this browser session.</span>
+              </div>
+            </div>
+          )}
+
+          {sampleLoad.status === "error" && (
+            <div className="dna-chat-sample-notice error">
+              <div>
+                <strong>Sample results could not be loaded.</strong>
+                <span>{sampleLoad.error}</span>
+              </div>
+            </div>
+          )}
+
           <LLMChatInline onOpenTour={() => setTourOpen(true)} />
         </section>
       </main>

--- a/app/dna-chat/page.tsx
+++ b/app/dna-chat/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import MenuBar from "../components/MenuBar";
 import Footer from "../components/Footer";
 import LLMChatInline from "../components/LLMChatInline";
-import GuidedTour, { hasCompletedTour } from "../components/GuidedTour";
+import GuidedTour from "../components/GuidedTour";
 import { dnaChatTour } from "../components/tours/tourContent";
 import { useResults } from "../components/ResultsContext";
 import { ResultsManager } from "@/lib/results-manager";
@@ -44,11 +44,6 @@ export default function DNAChatPage() {
     trackDNAChatViewed();
   }, []);
 
-  useEffect(() => {
-    if (!hasCompletedTour(dnaChatTour.id)) {
-      setTourOpen(true);
-    }
-  }, []);
 
   useEffect(() => {
     if (typeof window === "undefined" || sampleLoadStartedRef.current) return;
@@ -182,10 +177,8 @@ export default function DNAChatPage() {
             <div className="dna-chat-sample-notice ready">
               <div>
                 <strong>Sample data loaded.</strong>
-                <span>Using {sampleLoad.resultCount.toLocaleString()} sample results. To use your own DNA, click My Data, upload your file, then click Run All.</span>
-                <br/>
-                <span>No DNA test yet? <a href="https://docs.google.com/forms/d/e/1FAIpQLSdHFDpsyU0t6PlaXEkbHX-pwF_y7icuPJeOHyGHMDpe11XigQ/viewform?usp=sharing&ouid=117844628488835974298" target="_blank" rel="noopener noreferrer" className="dna-chat-sample-notice-link">Sign up</a>  for a private, anonymous DNA test with us. We do not store or resell your data.</span>
-                <br/>
+                <span>To use your own DNA, click My Data, upload your file, then click Run All.</span>
+                <span>Or <a href="https://docs.google.com/forms/d/e/1FAIpQLSdHFDpsyU0t6PlaXEkbHX-pwF_y7icuPJeOHyGHMDpe11XigQ/viewform?usp=sharing&ouid=117844628488835974298" target="_blank" rel="noopener noreferrer" className="dna-chat-sample-notice-link">sign up</a> for a private, anonymous sequencing.</span>
               </div>
             </div>
           )}
@@ -208,7 +201,16 @@ export default function DNAChatPage() {
             </div>
           )}
 
-          <LLMChatInline />
+          <div className="dna-chat-inline-wrapper">
+            <button
+              className="dna-chat-tour-button"
+              type="button"
+              onClick={() => setTourOpen(true)}
+            >
+              Show me how to use this
+            </button>
+            <LLMChatInline />
+          </div>
         </section>
       </main>
       <Footer />

--- a/app/dna-chat/page.tsx
+++ b/app/dna-chat/page.tsx
@@ -183,6 +183,9 @@ export default function DNAChatPage() {
               <div>
                 <strong>Sample data loaded.</strong>
                 <span>Using {sampleLoad.resultCount.toLocaleString()} sample results. To use your own DNA, click My Data, upload your file, then click Run All.</span>
+                <br/>
+                <span>No DNA test yet? <a href="https://docs.google.com/forms/d/e/1FAIpQLSdHFDpsyU0t6PlaXEkbHX-pwF_y7icuPJeOHyGHMDpe11XigQ/viewform?usp=sharing&ouid=117844628488835974298" target="_blank" rel="noopener noreferrer" className="dna-chat-sample-notice-link">Sign up</a>  for a private, anonymous DNA test with us. We do not store or resell your data.</span>
+                <br/>
               </div>
             </div>
           )}

--- a/app/globals.css
+++ b/app/globals.css
@@ -11024,3 +11024,87 @@ details[open] .summary-arrow {
     max-width: calc(100vw - 24px);
   }
 }
+
+
+.new-user-choice-slide {
+  padding: 1rem 0 0.5rem;
+}
+
+.new-user-choice-list {
+  width: min(560px, 100%);
+  margin-top: 0.65rem;
+}
+
+.dna-chat-open-header .premium-header-content {
+  justify-content: space-between;
+}
+
+.dna-chat-sample-notice {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem 1rem;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-left: 4px solid #0f766e;
+  border-radius: 8px;
+  background: #ffffff;
+  color: var(--text-secondary);
+}
+
+.dna-chat-sample-notice > div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.dna-chat-sample-notice strong {
+  color: var(--text-primary);
+  font-size: 0.95rem;
+}
+
+.dna-chat-sample-notice span {
+  line-height: 1.45;
+}
+
+.dna-chat-sample-notice .wire-progress-bar {
+  width: min(220px, 32vw);
+  flex: 0 0 auto;
+  margin: 0;
+}
+
+.dna-chat-sample-notice button {
+  flex: 0 0 auto;
+  padding: 0.55rem 0.85rem;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  border-radius: 8px;
+  background: #111111;
+  color: #ffffff;
+  font-weight: 750;
+  cursor: pointer;
+}
+
+.dna-chat-sample-notice button:hover {
+  background: #2f2f2f;
+}
+
+.dna-chat-sample-notice.error {
+  border-left-color: #dc2626;
+  background: rgba(239, 68, 68, 0.06);
+}
+
+@media (max-width: 720px) {
+  .dna-chat-sample-notice {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .dna-chat-sample-notice .wire-progress-bar {
+    width: 100%;
+  }
+
+  .dna-chat-sample-notice button {
+    width: 100%;
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -5887,7 +5887,7 @@ details[open] .summary-arrow {
 }
 
 .dna-chat-page .premium-compact-header {
-  max-width: 1180px;
+  max-width: 1560px;
   padding: 1rem 1.5rem 0.55rem;
 }
 
@@ -5899,7 +5899,7 @@ details[open] .summary-arrow {
 }
 
 .dna-chat-section {
-  width: min(1180px, calc(100% - 3rem));
+  width: min(1560px, calc(100% - 3rem));
   padding: 0 0 1.5rem;
 }
 
@@ -5969,6 +5969,26 @@ details[open] .summary-arrow {
 .dna-chat-section .rag-info-followup {
   color: rgba(26, 26, 26, 0.58);
   font-weight: 750;
+}
+
+.dna-chat-section .rag-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.dna-chat-section .rag-hint {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: rgba(26, 26, 26, 0.44);
+}
+
+.dna-chat-section .rag-hint.rag-hint-warn {
+  color: rgba(161, 90, 0, 0.75);
+}
+
+.dna-chat-section .rag-hint.rag-hint-ok {
+  color: rgba(15, 118, 110, 0.8);
 }
 
 .dna-chat-section .chat-action-button {
@@ -6217,6 +6237,18 @@ details[open] .summary-arrow {
 :root[data-theme="dark"] .dna-chat-section .ai-chat-inline .chat-messages,
 :root[data-theme="dark"] .dna-chat-section .chat-footer-disclaimer {
   background: rgba(0, 0, 0, 0.42);
+}
+
+:root[data-theme="dark"] .dna-chat-section .rag-hint {
+  color: rgba(255, 255, 255, 0.32);
+}
+
+:root[data-theme="dark"] .dna-chat-section .rag-hint.rag-hint-warn {
+  color: rgba(251, 191, 36, 0.6);
+}
+
+:root[data-theme="dark"] .dna-chat-section .rag-hint.rag-hint-ok {
+  color: rgba(52, 211, 153, 0.7);
 }
 
 :root[data-theme="dark"] .dna-chat-title-mark,
@@ -11035,16 +11067,12 @@ details[open] .summary-arrow {
   margin-top: 0.65rem;
 }
 
-.dna-chat-open-header .premium-header-content {
-  justify-content: space-between;
-}
-
 .dna-chat-sample-notice {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
-  padding: 0.85rem 1rem;
+  gap: 0.75rem;
+  padding: 0.5rem 0.7rem;
   border: 1px solid rgba(15, 23, 42, 0.08);
   border-left: 4px solid #0f766e;
   border-radius: 8px;
@@ -11055,38 +11083,24 @@ details[open] .summary-arrow {
 .dna-chat-sample-notice > div {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.15rem;
   min-width: 0;
 }
 
 .dna-chat-sample-notice strong {
   color: var(--text-primary);
-  font-size: 0.95rem;
+  font-size: 0.88rem;
 }
 
 .dna-chat-sample-notice span {
-  line-height: 1.45;
+  line-height: 1.25;
+  font-size: 0.86rem;
 }
 
 .dna-chat-sample-notice .wire-progress-bar {
   width: min(220px, 32vw);
   flex: 0 0 auto;
   margin: 0;
-}
-
-.dna-chat-sample-notice button {
-  flex: 0 0 auto;
-  padding: 0.55rem 0.85rem;
-  border: 1px solid rgba(15, 23, 42, 0.12);
-  border-radius: 8px;
-  background: #111111;
-  color: #ffffff;
-  font-weight: 750;
-  cursor: pointer;
-}
-
-.dna-chat-sample-notice button:hover {
-  background: #2f2f2f;
 }
 
 .dna-chat-sample-notice.error {
@@ -11103,8 +11117,58 @@ details[open] .summary-arrow {
   .dna-chat-sample-notice .wire-progress-bar {
     width: 100%;
   }
+}
 
-  .dna-chat-sample-notice button {
-    width: 100%;
+.dna-chat-section .example-questions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.35rem;
+  margin: 0.4rem auto 0;
+  max-width: 980px;
+}
+
+.dna-chat-section .example-questions li {
+  min-height: 32px;
+  padding: 0.38rem 0.55rem;
+  white-space: nowrap;
+  font-size: 0.74rem;
+  line-height: 1;
+}
+
+.dna-chat-section .chat-footer-disclaimer {
+  padding: 0.45rem 0.75rem;
+  font-size: 0.74rem;
+  line-height: 1.25;
+  text-align: center;
+}
+
+@media (max-width: 900px) {
+  .dna-chat-section .example-questions {
+    justify-content: flex-start;
+  }
+
+  .dna-chat-section .example-questions li {
+    white-space: normal;
+    line-height: 1.15;
   }
 }
+
+.dna-chat-page {
+  min-height: calc(100vh - 88px);
+}
+
+.dna-chat-section {
+  padding-bottom: 1rem;
+}
+
+.dna-chat-section .ai-chat-inline {
+  height: clamp(480px, calc(100vh - 250px), 1040px);
+}
+
+@media (max-width: 900px) {
+  .dna-chat-section .ai-chat-inline {
+    height: clamp(420px, calc(100vh - 215px), 980px);
+  }
+}
+

--- a/app/globals.css
+++ b/app/globals.css
@@ -11129,6 +11129,16 @@ details[open] .summary-arrow {
   margin: 0;
 }
 
+.dna-chat-sample-notice-link {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.dna-chat-sample-notice-link:hover {
+  opacity: 0.75;
+}
+
 .dna-chat-sample-notice.error {
   border-left-color: #dc2626;
   background: rgba(239, 68, 68, 0.06);

--- a/app/globals.css
+++ b/app/globals.css
@@ -11204,7 +11204,33 @@ details[open] .summary-arrow {
 
 @media (max-width: 900px) {
   .dna-chat-section .ai-chat-inline {
-    height: clamp(420px, calc(100vh - 215px), 980px);
+    height: clamp(360px, calc(100vh - 290px), 980px);
+    height: clamp(360px, calc(100svh - 230px), 980px);
   }
+}
+
+.dna-chat-inline-wrapper {
+  position: relative;
+}
+
+.dna-chat-tour-button {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.6rem;
+  z-index: 10;
+  padding: 0.25rem 0.6rem;
+  border-radius: 4px;
+  border: 1px solid rgba(15, 23, 42, 0.18);
+  background: rgba(255, 255, 255, 0.9);
+  color: rgba(15, 23, 42, 0.55);
+  font-size: 0.72rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.dna-chat-tour-button:hover {
+  background: #ffffff;
+  color: rgba(15, 23, 42, 0.85);
+  border-color: rgba(15, 23, 42, 0.35);
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -9561,6 +9561,32 @@ details[open] .summary-arrow {
   margin-top: 0.35rem;
 }
 
+.new-user-redirect-text {
+  font-size: 1.05rem;
+  font-weight: 500;
+  color: #111111;
+  text-align: center;
+  max-width: 360px;
+  line-height: 1.5;
+  margin: 0 auto 1rem;
+}
+
+.new-user-countdown {
+  font-size: 3.5rem;
+  font-weight: 700;
+  color: #111111;
+  text-align: center;
+  line-height: 1;
+  margin: 0.5rem auto 1.25rem;
+  width: 4rem;
+  height: 4rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 3px solid #111111;
+  border-radius: 50%;
+}
+
 .wire-onboarding-choice-list,
 .wire-onboarding-actions,
 .wire-response-list {

--- a/app/landing-client.tsx
+++ b/app/landing-client.tsx
@@ -164,15 +164,6 @@ export default function LandingClient() {
           <aside className="landing-home-start-panel" aria-labelledby="landing-start-heading">
             <h2 id="landing-start-heading">Get Started</h2>
             <div className="landing-start-actions">
-              <button
-                className="landing-secondary-button"
-                onClick={() => {
-                  trackGetStartedClicked("welcome_options");
-                  setShowWelcomeChoice(true);
-                }}
-              >
-                Choose How to Start
-              </button>
               <a
                 className="landing-secondary-button"
                 href={INSTRUCTIONAL_VIDEO_URL}

--- a/app/landing-client.tsx
+++ b/app/landing-client.tsx
@@ -2,14 +2,14 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import ConversionOnboarding from "./components/ConversionOnboarding";
 import { useGenotype } from "./components/UserDataUpload";
 import { trackGetStartedClicked } from "@/lib/analytics";
 
-type FlowMode = "guided" | "instant_preview";
 
 const INSTRUCTIONAL_VIDEO_URL = "https://youtu.be/1mqLYTAOK90";
 const SCHEDULE_CALL_URL = "https://calendar.app.google/eVDN4d44GreUjR8p8";
+const NEW_USER_CHOICE_STORAGE_KEY = "new_user_choice_completed";
+const MOTHBALLED_ONBOARDING_STORAGE_KEY = "conversion_onboarding_completed";
 
 const introCopy = [
   {
@@ -30,27 +30,78 @@ const introCopy = [
   },
 ];
 
+function NewUserChoiceModal({
+  isOpen,
+  onClose,
+  onTryChat,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  onTryChat: () => void;
+}) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="wire-onboarding-overlay">
+      <div className="wire-onboarding-shell">
+        <div className="wire-onboarding-frame">
+          <button
+            className="wire-onboarding-close"
+            onClick={onClose}
+            aria-label="Close welcome options"
+          >
+            ✕
+          </button>
+          <div className="wire-onboarding-step">Welcome</div>
+          <section className="wire-onboarding-slide new-user-choice-slide">
+            <h1>Start with the full app overview or try DNA Chat with sample results.</h1>
+            <p>
+              You can learn how Monadic DNA Explorer works first, or jump straight into
+              DNA Chat with a prepared result set.
+            </p>
+            <div className="wire-onboarding-choice-list new-user-choice-list">
+              <button
+                className="wire-onboarding-choice primary"
+                onClick={onClose}
+                type="button"
+              >
+                Go to the home page
+              </button>
+              <button
+                className="wire-onboarding-choice"
+                onClick={onTryChat}
+                type="button"
+              >
+                Try DNA Chat directly
+              </button>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function LandingClient() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { isUploaded, error } = useGenotype();
-  const [showFlow, setShowFlow] = useState(false);
-  const [flowMode, setFlowMode] = useState<FlowMode>("guided");
+  const { error } = useGenotype();
+  const [showWelcomeChoice, setShowWelcomeChoice] = useState(false);
 
-  const openOnboarding = useCallback((mode: FlowMode = "guided") => {
-    setFlowMode(mode);
-    setShowFlow(true);
+  const completeWelcomeChoice = useCallback(() => {
+    localStorage.setItem(NEW_USER_CHOICE_STORAGE_KEY, "true");
+    localStorage.setItem(MOTHBALLED_ONBOARDING_STORAGE_KEY, "true");
+    setShowWelcomeChoice(false);
   }, []);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
 
-    const completed = localStorage.getItem("conversion_onboarding_completed") === "true";
+    const completed = localStorage.getItem(NEW_USER_CHOICE_STORAGE_KEY) === "true";
     const forceOpen = searchParams.get("onboarding") === "1";
 
     if (forceOpen || !completed) {
-      setFlowMode(forceOpen ? "guided" : isUploaded ? "instant_preview" : "guided");
-      setShowFlow(true);
+      setShowWelcomeChoice(true);
     }
 
     if (forceOpen) {
@@ -58,30 +109,31 @@ export default function LandingClient() {
       url.searchParams.delete("onboarding");
       window.history.replaceState({}, "", url.toString());
     }
-  }, [isUploaded, searchParams]);
+  }, [searchParams]);
 
   useEffect(() => {
-    const handleOpen = (event: Event) => {
-      const customEvent = event as CustomEvent<{ mode?: FlowMode }>;
-      openOnboarding(customEvent.detail?.mode || "guided");
+    const handleOpen = () => {
+      setShowWelcomeChoice(true);
     };
 
     window.addEventListener("openConversionOnboarding", handleOpen as EventListener);
+    window.addEventListener("openNewUserChoiceModal", handleOpen as EventListener);
     return () => {
       window.removeEventListener("openConversionOnboarding", handleOpen as EventListener);
+      window.removeEventListener("openNewUserChoiceModal", handleOpen as EventListener);
     };
-  }, [openOnboarding]);
+  }, []);
 
   return (
     <>
-      <ConversionOnboarding
-        isOpen={showFlow}
-        mode={flowMode}
-        onComplete={() => {
-          setShowFlow(false);
-          router.push("/");
+      <NewUserChoiceModal
+        isOpen={showWelcomeChoice}
+        onClose={completeWelcomeChoice}
+        onTryChat={() => {
+          completeWelcomeChoice();
+          trackGetStartedClicked("try_dna_chat_directly");
+          router.push("/dna-chat?sample=1");
         }}
-        onDismiss={() => setShowFlow(false)}
       />
 
       <main className="page landing-page landing-home-page">
@@ -107,11 +159,11 @@ export default function LandingClient() {
               <button
                 className="landing-secondary-button"
                 onClick={() => {
-                  trackGetStartedClicked("onboarding_tour");
-                  openOnboarding(isUploaded ? "instant_preview" : "guided");
+                  trackGetStartedClicked("welcome_options");
+                  setShowWelcomeChoice(true);
                 }}
               >
-                Take an Onboarding Tour
+                Choose How to Start
               </button>
               <a
                 className="landing-secondary-button"

--- a/app/landing-client.tsx
+++ b/app/landing-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useGenotype } from "./components/UserDataUpload";
 import { trackGetStartedClicked } from "@/lib/analytics";
@@ -39,42 +39,51 @@ function NewUserChoiceModal({
   onClose: () => void;
   onTryChat: () => void;
 }) {
+  const [countdown, setCountdown] = useState(5);
+  const onTryChatRef = useRef(onTryChat);
+  onTryChatRef.current = onTryChat;
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setCountdown(5);
+    const interval = setInterval(() => {
+      setCountdown(prev => {
+        if (prev <= 1) {
+          clearInterval(interval);
+          onTryChatRef.current();
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [isOpen]);
+
   if (!isOpen) return null;
 
   return (
     <div className="wire-onboarding-overlay">
       <div className="wire-onboarding-shell">
         <div className="wire-onboarding-frame">
-          <button
-            className="wire-onboarding-close"
-            onClick={onClose}
-            aria-label="Close welcome options"
-          >
-            ✕
-          </button>
-          <div className="wire-onboarding-step">Welcome</div>
           <section className="wire-onboarding-slide new-user-choice-slide">
-            <h1>Start with the full app overview or try DNA Chat with sample results.</h1>
-            <p>
-              You can learn how Monadic DNA Explorer works first, or jump straight into
-              DNA Chat with a prepared result set.
+            <p className="new-user-redirect-text">
+              We are automatically redirecting you to our DNA Chat page so you can see our app in action.
             </p>
-            <div className="wire-onboarding-choice-list new-user-choice-list">
-              <button
-                className="wire-onboarding-choice"
-                onClick={onClose}
-                type="button"
-              >
-                Go to the home page
-              </button>
-              <button
-                className="wire-onboarding-choice"
-                onClick={onTryChat}
-                type="button"
-              >
-                Try DNA Chat directly
-              </button>
-            </div>
+            <div className="new-user-countdown">{countdown}</div>
+            <button
+              className="wire-onboarding-choice"
+              onClick={onClose}
+              type="button"
+            >
+              Click here to just go to the home page to learn about the app
+            </button>
+            <button
+              className="wire-onboarding-text-link"
+              onClick={onClose}
+              type="button"
+            >
+              Never show this again
+            </button>
           </section>
         </div>
       </div>

--- a/app/landing-client.tsx
+++ b/app/landing-client.tsx
@@ -61,7 +61,7 @@ function NewUserChoiceModal({
             </p>
             <div className="wire-onboarding-choice-list new-user-choice-list">
               <button
-                className="wire-onboarding-choice primary"
+                className="wire-onboarding-choice"
                 onClick={onClose}
                 type="button"
               >

--- a/app/landing-client.tsx
+++ b/app/landing-client.tsx
@@ -47,17 +47,16 @@ function NewUserChoiceModal({
     if (!isOpen) return;
     setCountdown(5);
     const interval = setInterval(() => {
-      setCountdown(prev => {
-        if (prev <= 1) {
-          clearInterval(interval);
-          onTryChatRef.current();
-          return 0;
-        }
-        return prev - 1;
-      });
+      setCountdown(prev => (prev <= 1 ? 0 : prev - 1));
     }, 1000);
     return () => clearInterval(interval);
   }, [isOpen]);
+
+  useEffect(() => {
+    if (countdown === 0 && isOpen) {
+      onTryChatRef.current();
+    }
+  }, [countdown, isOpen]);
 
   if (!isOpen) return null;
 

--- a/app/landing-client.tsx
+++ b/app/landing-client.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useGenotype } from "./components/UserDataUpload";
-import { trackGetStartedClicked } from "@/lib/analytics";
+import { trackGetStartedClicked, trackIntroModalShown } from "@/lib/analytics";
 
 
 const INSTRUCTIONAL_VIDEO_URL = "https://youtu.be/1mqLYTAOK90";
@@ -110,6 +110,7 @@ export default function LandingClient() {
 
     if (forceOpen || !completed) {
       setShowWelcomeChoice(true);
+      trackIntroModalShown();
     }
 
     if (forceOpen) {

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -389,11 +389,15 @@ export function trackPremiumSectionViewed() {
 /**
  * User viewed a premium tab
  */
-export function trackPremiumTabViewed(tab: string, hasPremiumAccess: boolean) {
-  trackEvent('premium_tab_viewed', {
-    tab,
+export function trackOverviewReportTabViewed(hasPremiumAccess: boolean) {
+  trackEvent('overview_report_tab_viewed', {
     has_premium_access: hasPremiumAccess,
   });
+}
+
+/** @deprecated Use trackOverviewReportTabViewed instead */
+export function trackPremiumTabViewed(tab: string, hasPremiumAccess: boolean) {
+  trackOverviewReportTabViewed(hasPremiumAccess);
 }
 
 /**

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -190,7 +190,7 @@ export function trackOnboardingDismissed(step: string) {
 /**
  * User clicked one of the homepage Get Started actions
  */
-export function trackGetStartedClicked(action: 'onboarding_tour' | 'instructional_video' | 'schedule_video_call' | 'restart_onboarding') {
+export function trackGetStartedClicked(action: 'onboarding_tour' | 'welcome_options' | 'try_dna_chat_directly' | 'instructional_video' | 'schedule_video_call' | 'restart_onboarding') {
   trackEvent('get_started_clicked', {
     action,
   });

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -458,6 +458,10 @@ export function trackLLMQuestionAsked(params?: { isFollowUp?: boolean }) {
   });
 }
 
+export function trackIntroModalShown() {
+  trackEvent('intro_modal_shown');
+}
+
 export function trackDNAChatViewed() {
   trackEvent('dna_chat_viewed');
 }


### PR DESCRIPTION
New user onboarding: replaced the multi-option welcome modal with a 5-second auto-redirect countdown to DNA Chat. Users can cancel to stay on the home page or dismiss permanently. Removed the "Choose How to Start" button from the landing page.

DNA Chat cleanup: removed paywalls, subscription gates, the personalization banner, and the provider tip banner. Replaced them with compact inline hints near the send button showing results count and personalization status. Added Print/Clear controls at both top and bottom of the chat. Reordered message elements (copy button, studies used, follow-up suggestions). Guided tour no longer auto-launches on page load; replaced with a "Show me how to use this" button that triggers it on demand.

Sample data: DNA Chat loads sample results automatically when redirected from the intro modal, with a compact status notice that includes a CTA to sign up for sequencing.

Mobile: the mobile compatibility notice now only appears when Run All is clicked, not on page load.

Footer: added Terms and Conditions and Privacy Policy links.

Analytics: added intro_modal_shown event; renamed premium_tab_viewed to overview_report_tab_viewed; confirmed dna_chat_viewed and llm_question_asked coverage.