### PR TITLE
Research in Chat, Paywall Restructure

### DIFF
--- a/app/components/ConversionOnboarding.tsx
+++ b/app/components/ConversionOnboarding.tsx
@@ -10,11 +10,9 @@ import { runAllAnalysisOnboarding, type OnboardingRunAllProgress } from "@/lib/r
 import { useGenotype } from "./UserDataUpload";
 import { useResults } from "./ResultsContext";
 import LLMCommentaryModal from "./LLMCommentaryModal";
-import NilAIConsentModal from "./NilAIConsentModal";
+
 import { callLLM, getLLMDescription } from "@/lib/llm-client";
 import {
-  trackAIConsentDeclined,
-  trackAIConsentGiven,
   trackLLMQuestionAsked,
   trackOnboardingAction,
   trackOnboardingCompleted,
@@ -55,7 +53,6 @@ interface ConversionOnboardingProps {
   mode?: FlowMode;
 }
 
-const CONSENT_STORAGE_KEY = "nilai_llm_consent_accepted";
 const SAMPLE_DATA_URL = "/api/sample-genotype";
 const GUIDE_23ANDME_URL = "https://monadicdna.com/guide/23andme";
 const GUIDE_ANCESTRY_URL = "https://monadicdna.com/guide/ancestry";
@@ -228,8 +225,6 @@ export default function ConversionOnboarding({
   const [mounted, setMounted] = useState(false);
   const [currentStep, setCurrentStep] = useState<OnboardingStep>("intro");
   const [completionPath, setCompletionPath] = useState<CompletionPath>("own_dna");
-  const [showConsentModal, setShowConsentModal] = useState(false);
-  const [hasConsent, setHasConsent] = useState(false);
   const [traitCandidates, setTraitCandidates] = useState<SavedResult[]>([]);
   const [selectedTraitIds, setSelectedTraitIds] = useState<number[]>([]);
   const [previewResponses, setPreviewResponses] = useState<PreviewChatAnswer[]>([]);
@@ -242,7 +237,6 @@ export default function ConversionOnboarding({
   const [detailResult, setDetailResult] = useState<SavedResult | null>(null);
   const [expandedTraitId, setExpandedTraitId] = useState<number | null>(null);
   const [commentaryResult, setCommentaryResult] = useState<SavedResult | null>(null);
-  const [pendingQuestion, setPendingQuestion] = useState<string | null>(null);
   const [activeQuestion, setActiveQuestion] = useState<string | null>(null);
   const [runAllProgress, setRunAllProgress] = useState<OnboardingRunAllProgress>({
     phase: "downloading",
@@ -260,9 +254,6 @@ export default function ConversionOnboarding({
 
   useEffect(() => {
     setMounted(true);
-    if (typeof window !== "undefined") {
-      setHasConsent(localStorage.getItem(CONSENT_STORAGE_KEY) === "true");
-    }
   }, []);
 
   useEffect(() => {
@@ -601,26 +592,6 @@ RESPONSE STRUCTURE:
         />
       )}
 
-      <NilAIConsentModal
-        isOpen={showConsentModal}
-        onAccept={() => {
-          localStorage.setItem(CONSENT_STORAGE_KEY, "true");
-          setHasConsent(true);
-          setShowConsentModal(false);
-          trackAIConsentGiven();
-          if (pendingQuestion) {
-            const nextQuestion = pendingQuestion;
-            setPendingQuestion(null);
-            void generateSecureResponses(nextQuestion);
-            return;
-          }
-        }}
-        onDecline={() => {
-          setPendingQuestion(null);
-          setShowConsentModal(false);
-          trackAIConsentDeclined();
-        }}
-      />
 
       <div className="wire-onboarding-overlay">
         <div className="wire-onboarding-shell">
@@ -1093,12 +1064,6 @@ RESPONSE STRUCTURE:
                             trackOnboardingAction("chat_preview_question_selected");
 
                             if (response) {
-                              return;
-                            }
-
-                            if (!hasConsent) {
-                              setPendingQuestion(question);
-                              setShowConsentModal(true);
                               return;
                             }
 

--- a/app/components/ConversionOnboarding.tsx
+++ b/app/components/ConversionOnboarding.tsx
@@ -274,9 +274,7 @@ export default function ConversionOnboarding({
     setDetailResult(null);
     setExpandedTraitId(null);
     setCommentaryResult(null);
-    setPendingQuestion(null);
     setActiveQuestion(null);
-    setShowConsentModal(false);
     setRunAllProgress({
       phase: "downloading",
       loaded: 0,
@@ -299,11 +297,6 @@ export default function ConversionOnboarding({
       });
     }
   }, [completionPath, currentStep, isOpen, mode, mounted]);
-
-  useEffect(() => {
-    if (typeof window === "undefined" || commentaryResult) return;
-    setHasConsent(localStorage.getItem(CONSENT_STORAGE_KEY) === "true");
-  }, [commentaryResult]);
 
   const selectedTraitResults = useMemo(
     () => traitCandidates.filter((result) => selectedTraitIds.includes(result.studyId)),
@@ -568,7 +561,6 @@ RESPONSE STRUCTURE:
     setResponseError(null);
     setResponsesLoading(false);
     setDetailResult(null);
-    setPendingQuestion(null);
     setActiveQuestion(null);
 
     setCurrentStep("responses");

--- a/app/components/LLMChatInline.tsx
+++ b/app/components/LLMChatInline.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import { SavedResult } from "@/lib/results-manager";
 import { useResults } from "./ResultsContext";
 import { useCustomization } from "./CustomizationContext";
-import { useAuth, AuthButton } from "./AuthProvider";
+import { useAuth } from "./AuthProvider";
 import { hasValidPromoAccess } from "@/lib/promo-access";
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -58,7 +58,7 @@ export default function AIChatInline({ initialInput }: { initialInput?: string }
   const resultsContext = useResults();
   const { getTopResultsByRelevance } = resultsContext;
   const { customization, status: customizationStatus } = useCustomization();
-  const { isAuthenticated, hasActiveSubscription, openAuthModal, initializeDynamic, isDynamicInitialized } = useAuth();
+  const { isAuthenticated, hasActiveSubscription, openAuthModal } = useAuth();
   const [hasPromoAccess, setHasPromoAccess] = useState(false);
   const [mounted, setMounted] = useState(false);
   const [messages, setMessages] = useState<Message[]>([]);
@@ -93,10 +93,6 @@ export default function AIChatInline({ initialInput }: { initialInput?: string }
     window.addEventListener('premiumAccessUpdated', refresh);
     return () => window.removeEventListener('premiumAccessUpdated', refresh);
   }, []);
-
-  useEffect(() => {
-    if (!isDynamicInitialized) initializeDynamic();
-  }, [initializeDynamic, isDynamicInitialized]);
 
   const hasPremiumAccess = hasActiveSubscription || hasPromoAccess;
 
@@ -967,7 +963,7 @@ Write questions from the user's perspective — as if the user is asking you. No
         <div className="chat-messages">
           {messages.length === 0 && (
             <div className="chat-welcome">
-              {}
+              <p className="chat-welcome-prompt">Try asking something about your results:</p>
 
               <ul className="example-questions">
                 {EXAMPLE_QUESTIONS.map((question) => (
@@ -1228,9 +1224,6 @@ Write questions from the user's perspective — as if the user is asking you. No
               </div>
             )}
             <div className="chat-buttons">
-              <div className="chat-dynamic-widget">
-                <AuthButton />
-              </div>
               <button
                 className="chat-attachment-button"
                 onClick={handleAttachmentClick}
@@ -1257,8 +1250,10 @@ Write questions from the user's perspective — as if the user is asking you. No
                 {isLoading ? 'Sending...' : 'Send'}
               </button>
             </div>
+          </div>
+          <div className="chat-input-footer">
             <p className="chat-research-hint">
-              <strong>Send</strong> answers your question directly. <strong>Research</strong> searches 10 genetic angles and synthesizes a deeper answer.
+              <strong>Send</strong> — quick answer. <strong>Research</strong> — explores 10 genetic angles in depth.
             </p>
           </div>
         </div>

--- a/app/components/LLMChatInline.tsx
+++ b/app/components/LLMChatInline.tsx
@@ -1,13 +1,17 @@
 "use client";
 
 import { useEffect, useState, useRef } from "react";
+import { useRouter } from "next/navigation";
 import { SavedResult } from "@/lib/results-manager";
 import { useResults } from "./ResultsContext";
 import { useCustomization } from "./CustomizationContext";
+import { useAuth, AuthButton } from "./AuthProvider";
+import { hasValidPromoAccess } from "@/lib/promo-access";
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { callLLM, callLLMStream, getLLMDescription, MessageContentPart } from "@/lib/llm-client";
 import { trackLLMQuestionAsked, trackExampleQuestionClicked, trackFollowupQuestionClicked } from "@/lib/analytics";
+import { runResearchPipeline, type ResearchAngle } from "@/lib/research-service";
 
 type AttachmentType = 'text' | 'pdf' | 'csv' | 'tsv' | 'image';
 
@@ -28,6 +32,7 @@ type Message = {
   studiesUsed?: SavedResult[];
   attachments?: Attachment[];
   followupQuestions?: string[];
+  researchMeta?: ResearchAngle[];
 };
 
 const MAX_CONTEXT_RESULTS = 500;
@@ -49,9 +54,12 @@ const EXAMPLE_QUESTIONS = [
 
 
 export default function AIChatInline({ initialInput }: { initialInput?: string } = {}) {
+  const router = useRouter();
   const resultsContext = useResults();
   const { getTopResultsByRelevance } = resultsContext;
   const { customization, status: customizationStatus } = useCustomization();
+  const { isAuthenticated, hasActiveSubscription, openAuthModal, initializeDynamic, isDynamicInitialized } = useAuth();
+  const [hasPromoAccess, setHasPromoAccess] = useState(false);
   const [mounted, setMounted] = useState(false);
   const [messages, setMessages] = useState<Message[]>([]);
   const [inputValue, setInputValue] = useState("");
@@ -70,6 +78,7 @@ export default function AIChatInline({ initialInput }: { initialInput?: string }
   const [attachedFiles, setAttachedFiles] = useState<File[]>([]);
   const [attachmentError, setAttachmentError] = useState<string | null>(null);
   const [expandedAttachmentIndex, setExpandedAttachmentIndex] = useState<number | null>(null);
+  const [expandedResearchIndex, setExpandedResearchIndex] = useState<number | null>(null);
 
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -77,6 +86,28 @@ export default function AIChatInline({ initialInput }: { initialInput?: string }
   useEffect(() => {
     setMounted(true);
   }, []);
+
+  useEffect(() => {
+    const refresh = () => setHasPromoAccess(hasValidPromoAccess());
+    refresh();
+    window.addEventListener('premiumAccessUpdated', refresh);
+    return () => window.removeEventListener('premiumAccessUpdated', refresh);
+  }, []);
+
+  useEffect(() => {
+    if (!isDynamicInitialized) initializeDynamic();
+  }, [initializeDynamic, isDynamicInitialized]);
+
+  const hasPremiumAccess = hasActiveSubscription || hasPromoAccess;
+
+  const requirePremium = (): boolean => {
+    if (!hasPremiumAccess && !hasValidPromoAccess()) {
+      if (!isAuthenticated) { openAuthModal(); return false; }
+      router.push('/subscribe');
+      return false;
+    }
+    return true;
+  };
 
   // Determine if this is the first message or a follow-up
   const isFirstMessage = messages.length === 0;
@@ -274,6 +305,48 @@ export default function AIChatInline({ initialInput }: { initialInput?: string }
     return parts;
   };
 
+  const buildUserContext = (): string => {
+    if (!customization) return '';
+    const parts: string[] = [];
+    if (customization.ethnicities.length > 0) {
+      parts.push(`Ethnicities: ${customization.ethnicities.join(', ')}`);
+    }
+    if (customization.countriesOfOrigin.length > 0) {
+      parts.push(`Countries of ancestral origin: ${customization.countriesOfOrigin.join(', ')}`);
+    }
+    if (customization.genderAtBirth) {
+      parts.push(`Gender assigned at birth: ${customization.genderAtBirth}`);
+    }
+    if (customization.age) {
+      parts.push(`Age: ${customization.age}`);
+    }
+    if (customization.smokingHistory) {
+      const smokingLabel = customization.smokingHistory === 'still-smoking' ? 'Currently smoking' :
+                           customization.smokingHistory === 'past-smoker' ? 'Former smoker' :
+                           'Never smoked';
+      parts.push(`Smoking history: ${smokingLabel}`);
+    }
+    if (customization.alcoholUse) {
+      const alcoholLabel = customization.alcoholUse.charAt(0).toUpperCase() + customization.alcoholUse.slice(1);
+      parts.push(`Alcohol use: ${alcoholLabel}`);
+    }
+    if (customization.medications && customization.medications.length > 0) {
+      parts.push(`Current medications/supplements: ${customization.medications.join(', ')}`);
+    }
+    if (customization.diet) {
+      const dietLabel = customization.diet === 'regular' ? 'Regular diet (no restrictions)' :
+                       customization.diet.charAt(0).toUpperCase() + customization.diet.slice(1) + ' diet';
+      parts.push(`Dietary preferences: ${dietLabel}`);
+    }
+    if (customization.personalConditions && customization.personalConditions.length > 0) {
+      parts.push(`Personal medical history: ${customization.personalConditions.join(', ')}`);
+    }
+    if (customization.familyConditions && customization.familyConditions.length > 0) {
+      parts.push(`Family medical history: ${customization.familyConditions.join(', ')}`);
+    }
+    return parts.join('\n');
+  };
+
   const handleSendMessage = async (queryOverride?: string) => {
     const query = (queryOverride ?? inputValue).trim();
     if (!query) return;
@@ -331,55 +404,10 @@ export default function AIChatInline({ initialInput }: { initialInput?: string }
 
       console.log(`[LLM Chat] Including ${relevantResults.length} results in LLM context`);
 
-      let userContext = '';
-      if (customization) {
-        const parts = [];
-        if (customization.ethnicities.length > 0) {
-          parts.push(`Ethnicities: ${customization.ethnicities.join(', ')}`);
-        }
-        if (customization.countriesOfOrigin.length > 0) {
-          parts.push(`Countries of ancestral origin: ${customization.countriesOfOrigin.join(', ')}`);
-        }
-        if (customization.genderAtBirth) {
-          parts.push(`Gender assigned at birth: ${customization.genderAtBirth}`);
-        }
-        if (customization.age) {
-          parts.push(`Age: ${customization.age}`);
-        }
-        if (customization.smokingHistory) {
-          const smokingLabel = customization.smokingHistory === 'still-smoking' ? 'Currently smoking' :
-                               customization.smokingHistory === 'past-smoker' ? 'Former smoker' :
-                               'Never smoked';
-          parts.push(`Smoking history: ${smokingLabel}`);
-        }
-        if (customization.alcoholUse) {
-          const alcoholLabel = customization.alcoholUse.charAt(0).toUpperCase() + customization.alcoholUse.slice(1);
-          parts.push(`Alcohol use: ${alcoholLabel}`);
-        }
-        if (customization.medications && customization.medications.length > 0) {
-          parts.push(`Current medications/supplements: ${customization.medications.join(', ')}`);
-        }
-        if (customization.diet) {
-          const dietLabel = customization.diet === 'regular' ? 'Regular diet (no restrictions)' :
-                           customization.diet.charAt(0).toUpperCase() + customization.diet.slice(1) + ' diet';
-          parts.push(`Dietary preferences: ${dietLabel}`);
-        }
-        if (customization.personalConditions && customization.personalConditions.length > 0) {
-          parts.push(`Personal medical history: ${customization.personalConditions.join(', ')}`);
-        }
-        if (customization.familyConditions && customization.familyConditions.length > 0) {
-          parts.push(`Family medical history: ${customization.familyConditions.join(', ')}`);
-        }
-
-        if (parts.length > 0) {
-          userContext = `
-
-USER BACKGROUND (CONFIDENTIAL - USE TO PERSONALIZE INTERPRETATION):
-${parts.join('\n')}
-
-Consider how this user's background, lifestyle factors (smoking, alcohol, diet), and current medications may affect their risk profile and the applicability of these study findings.`;
-        }
-      }
+      const userContextSummary = buildUserContext();
+      const userContext = userContextSummary
+        ? `\n\nUSER BACKGROUND (CONFIDENTIAL - USE TO PERSONALIZE INTERPRETATION):\n${userContextSummary}\n\nConsider how this user's background, lifestyle factors (smoking, alcohol, diet), and current medications may affect their risk profile and the applicability of these study findings.`
+        : '';
 
       const llmDescription = getLLMDescription();
 
@@ -667,6 +695,84 @@ Write questions from the user's perspective — as if the user is asking you. No
     }
   };
 
+  const handleResearch = async () => {
+    const query = inputValue.trim();
+    if (!query || isLoading) return;
+    if (!requirePremium()) return;
+
+    setInputValue('');
+    setIsLoading(true);
+    setError(null);
+    setAttachmentError(null);
+
+    trackLLMQuestionAsked({ isFollowUp: messages.length > 0 });
+
+    const userMessage: Message = { role: 'user', content: query, timestamp: new Date() };
+    const assistantMessage: Message = { role: 'assistant', content: '', timestamp: new Date() };
+    setMessages(prev => [...prev, userMessage, assistantMessage]);
+
+    try {
+      const llmDescription = getLLMDescription();
+      const customizationSummary = buildUserContext();
+
+      let capturedAngles: ResearchAngle[] | undefined;
+
+      const stream = runResearchPipeline(
+        query,
+        customizationSummary,
+        resultsContext.savedResults.length,
+        getTopResultsByRelevance,
+        setLoadingStatus,
+        llmDescription,
+        (angles) => { capturedAngles = angles; },
+      );
+
+      let accumulatedContent = '';
+      let isFirstChunk = true;
+
+      for await (const chunk of stream) {
+        if (isFirstChunk) {
+          setIsLoading(false);
+          setLoadingStatus('');
+          isFirstChunk = false;
+        }
+        accumulatedContent += chunk;
+        setMessages(prev => {
+          const updated = [...prev];
+          updated[updated.length - 1] = { ...updated[updated.length - 1], content: accumulatedContent };
+          return updated;
+        });
+      }
+
+      if (!accumulatedContent) throw new Error('No response from research pipeline.');
+
+      const followupMatch = accumulatedContent.split(/\n+FOLLOWUP:\n/);
+      const displayContent = followupMatch[0].trim();
+      const followupQuestions = followupMatch[1]
+        ? followupMatch[1].split('\n').filter(l => l.startsWith('- ')).map(l => l.slice(2).trim()).filter(Boolean)
+        : [];
+
+      setMessages(prev => {
+        const updated = [...prev];
+        updated[updated.length - 1] = { ...updated[updated.length - 1], content: displayContent, followupQuestions, researchMeta: capturedAngles };
+        return updated;
+      });
+    } catch (err) {
+      console.error('[Research] Error:', err);
+      let errorMessage = err instanceof Error ? err.message : 'Research failed.';
+      if (errorMessage.includes('429')) errorMessage = 'Rate limit exceeded. Please wait and try again.';
+      setError(errorMessage);
+      setMessages(prev => {
+        const lastMsg = prev[prev.length - 1];
+        if (lastMsg?.role === 'assistant' && !lastMsg.content) return prev.slice(0, -1);
+        return prev;
+      });
+    } finally {
+      setIsLoading(false);
+      setLoadingStatus('');
+    }
+  };
+
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
@@ -939,6 +1045,28 @@ Write questions from the user's perspective — as if the user is asking you. No
                     )}
                   </div>
                 )}
+                {message.role === 'assistant' && message.researchMeta && message.researchMeta.length > 0 && (
+                  <div className="studies-used">
+                    <button
+                      className="studies-toggle"
+                      onClick={() => setExpandedResearchIndex(expandedResearchIndex === idx ? null : idx)}
+                    >
+                      {expandedResearchIndex === idx ? '▼' : '▶'} Researched {message.researchMeta.length} angles
+                    </button>
+                    {expandedResearchIndex === idx && (
+                      <div className="studies-list">
+                        {message.researchMeta.map((angle, aidx) => (
+                          <div key={aidx} className="study-item">
+                            <div className="study-trait">{angle.keyword}</div>
+                            <div className="study-details">
+                              <span className="study-snp">{angle.resultsCount} studies searched</span>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )}
                 {message.role === 'assistant' && isLastAssistantMessage && !isLoading && (message.followupQuestions?.length ?? 0) > 0 && (
                   <div className="followup-suggestions">
                     <div className="followup-header">Try asking:</div>
@@ -1100,6 +1228,9 @@ Write questions from the user's perspective — as if the user is asking you. No
               </div>
             )}
             <div className="chat-buttons">
+              <div className="chat-dynamic-widget">
+                <AuthButton />
+              </div>
               <button
                 className="chat-attachment-button"
                 onClick={handleAttachmentClick}
@@ -1110,6 +1241,15 @@ Write questions from the user's perspective — as if the user is asking you. No
                 Attach
               </button>
               <button
+                className="chat-research-button"
+                onClick={handleResearch}
+                disabled={isLoading || !inputValue.trim()}
+                title="Searches 10 targeted keyword angles across your genetic data, then synthesizes findings into a comprehensive answer."
+              >
+                {isLoading ? 'Thinking...' : 'Research'}
+                <span className="chat-research-premium-badge">Premium</span>
+              </button>
+              <button
                 className="chat-send-button"
                 onClick={() => handleSendMessage()}
                 disabled={isLoading || !inputValue.trim()}
@@ -1117,6 +1257,9 @@ Write questions from the user's perspective — as if the user is asking you. No
                 {isLoading ? 'Sending...' : 'Send'}
               </button>
             </div>
+            <p className="chat-research-hint">
+              <strong>Send</strong> answers your question directly. <strong>Research</strong> searches 10 genetic angles and synthesizes a deeper answer.
+            </p>
           </div>
         </div>
 

--- a/app/components/LLMChatInline.tsx
+++ b/app/components/LLMChatInline.tsx
@@ -2,13 +2,12 @@
 
 import { useEffect, useState, useRef } from "react";
 import { SavedResult } from "@/lib/results-manager";
-import NilAIConsentModal from "./NilAIConsentModal";
 import { useResults } from "./ResultsContext";
 import { useCustomization } from "./CustomizationContext";
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { callLLM, callLLMStream, getLLMDescription, MessageContentPart } from "@/lib/llm-client";
-import { trackLLMQuestionAsked, trackAIConsentGiven, trackAIConsentDeclined, trackAIConsentModalShown, trackExampleQuestionClicked, trackFollowupQuestionClicked } from "@/lib/analytics";
+import { trackLLMQuestionAsked, trackExampleQuestionClicked, trackFollowupQuestionClicked } from "@/lib/analytics";
 
 type AttachmentType = 'text' | 'pdf' | 'csv' | 'tsv' | 'image';
 
@@ -31,7 +30,6 @@ type Message = {
   followupQuestions?: string[];
 };
 
-const CONSENT_STORAGE_KEY = "nilai_llm_chat_consent_accepted";
 const MAX_CONTEXT_RESULTS = 500;
 const MAX_TEXT_FILE_SIZE = 2 * 1024 * 1024; // 2MB for text/csv/tsv
 const MAX_PDF_FILE_SIZE = 5 * 1024 * 1024;  // 5MB for PDF
@@ -61,15 +59,13 @@ export default function AIChatInline({ initialInput }: { initialInput?: string }
   useEffect(() => {
     if (!initialInput) return;
     setInputValue(initialInput);
-    const t = setTimeout(() => handleSendMessage(false, initialInput), 0);
+    const t = setTimeout(() => handleSendMessage(initialInput), 0);
     return () => clearTimeout(t);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialInput]);
   const [isLoading, setIsLoading] = useState(false);
   const [loadingStatus, setLoadingStatus] = useState<string>("");
   const [error, setError] = useState<string | null>(null);
-  const [showConsentModal, setShowConsentModal] = useState(false);
-  const [hasConsent, setHasConsent] = useState(false);
   const [expandedMessageIndex, setExpandedMessageIndex] = useState<number | null>(null);
   const [attachedFiles, setAttachedFiles] = useState<File[]>([]);
   const [attachmentError, setAttachmentError] = useState<string | null>(null);
@@ -80,43 +76,14 @@ export default function AIChatInline({ initialInput }: { initialInput?: string }
 
   useEffect(() => {
     setMounted(true);
-
-    // Check consent
-    const consent = localStorage.getItem(CONSENT_STORAGE_KEY);
-    if (consent === 'true') {
-      setHasConsent(true);
-    }
   }, []);
 
   // Determine if this is the first message or a follow-up
   const isFirstMessage = messages.length === 0;
 
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      const consent = localStorage.getItem(CONSENT_STORAGE_KEY);
-      setHasConsent(consent === "true");
-    }
-  }, []);
-
 
   // Removed auto-scroll so user doesn't have to scroll up to read responses
   // Also removed auto-focus to prevent scrolling to bottom on tab load
-
-  const handleConsentAccept = () => {
-    if (typeof window !== "undefined") {
-      localStorage.setItem(CONSENT_STORAGE_KEY, "true");
-      setHasConsent(true);
-      setShowConsentModal(false);
-      trackAIConsentGiven();
-      void handleSendMessage(true);
-    }
-  };
-
-  const handleConsentDecline = () => {
-    setShowConsentModal(false);
-    trackAIConsentDeclined();
-  };
-
 
   const handleExampleClick = (question: string) => {
     setInputValue(question);
@@ -126,7 +93,7 @@ export default function AIChatInline({ initialInput }: { initialInput?: string }
 
   const handleFollowupClick = (question: string) => {
     trackFollowupQuestionClicked();
-    void handleSendMessage(false, question);
+    void handleSendMessage(question);
   };
 
   const handleCopyMessage = async (content: string) => {
@@ -307,16 +274,9 @@ export default function AIChatInline({ initialInput }: { initialInput?: string }
     return parts;
   };
 
-  const handleSendMessage = async (skipConsentCheck = false, queryOverride?: string) => {
+  const handleSendMessage = async (queryOverride?: string) => {
     const query = (queryOverride ?? inputValue).trim();
     if (!query) return;
-
-    // Check consent before sending first message
-    if (!skipConsentCheck && !hasConsent) {
-      setShowConsentModal(true);
-      trackAIConsentModalShown();
-      return;
-    }
 
     setInputValue("");
     setIsLoading(true);
@@ -884,13 +844,6 @@ Write questions from the user's perspective — as if the user is asking you. No
 
   return (
     <>
-      {showConsentModal && (
-        <NilAIConsentModal
-          isOpen={showConsentModal}
-          onAccept={handleConsentAccept}
-          onDecline={handleConsentDecline}
-        />
-      )}
       <div className="ai-chat-inline" style={{ position: 'relative' }}>
         {messages.length > 0 && (
           <div className="chat-info">

--- a/app/components/LLMCommentaryModal.tsx
+++ b/app/components/LLMCommentaryModal.tsx
@@ -692,7 +692,7 @@ Keep your response concise (400-600 words), educational, and reassuring where ap
 
   const handlePersonalizationPromptContinue = () => {
     setShowPersonalizationPrompt(false);
-    setShowConsentModal(true);
+    fetchCommentary();
   };
 
   if (!isOpen) return null;

--- a/app/components/LLMCommentaryModal.tsx
+++ b/app/components/LLMCommentaryModal.tsx
@@ -3,12 +3,12 @@
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { SavedResult } from "@/lib/results-manager";
-import NilAIConsentModal from "./NilAIConsentModal";
+
 import StudyQualityIndicators from "./StudyQualityIndicators";
 import { useResults } from "./ResultsContext";
 import { useCustomization } from "./CustomizationContext";
 import { callLLM, getLLMDescription } from "@/lib/llm-client";
-import { trackAIAnalysisRun } from "@/lib/analytics";
+
 
 type LLMCommentaryModalProps = {
   isOpen: boolean;
@@ -16,10 +16,7 @@ type LLMCommentaryModalProps = {
   currentResult: SavedResult;
   allResults: SavedResult[]; // Deprecated - will use SQL query instead
   skipPersonalizationPrompt?: boolean;
-  skipConsent?: boolean;
 };
-
-const CONSENT_STORAGE_KEY = "nilai_llm_consent_accepted";
 
 // Helper function to format risk scores consistently
 function formatRiskScore(score: number, level: string, effectType?: 'OR' | 'beta'): string {
@@ -36,7 +33,6 @@ export default function LLMCommentaryModal({
   currentResult,
   allResults, // Deprecated parameter
   skipPersonalizationPrompt = false,
-  skipConsent = false,
 }: LLMCommentaryModalProps) {
   const resultsContext = useResults();
   const { getTopResultsByRelevance } = resultsContext;
@@ -45,9 +41,7 @@ export default function LLMCommentaryModal({
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [delegationStatus, setDelegationStatus] = useState<string>("");
-  const [showConsentModal, setShowConsentModal] = useState(false);
   const [showPersonalizationPrompt, setShowPersonalizationPrompt] = useState(false);
-  const [hasConsent, setHasConsent] = useState(false);
   const [studyMetadata, setStudyMetadata] = useState<any>(null);
   const [loadingPhase, setLoadingPhase] = useState<'query' | 'metadata' | 'token' | 'llm' | 'done'>('query');
   const [resultsCount, setResultsCount] = useState<number>(0);
@@ -57,51 +51,16 @@ export default function LLMCommentaryModal({
   const [usedSemanticSearch, setUsedSemanticSearch] = useState<boolean>(false);
 
   useEffect(() => {
-    // Check if user has previously consented
-    if (typeof window !== "undefined") {
-      const consent = localStorage.getItem(CONSENT_STORAGE_KEY);
-      setHasConsent(consent === "true");
-    }
-  }, []);
-
-  useEffect(() => {
     if (isOpen) {
-      if (skipConsent) {
+      if (skipPersonalizationPrompt || customizationStatus === 'unlocked') {
         setShowPersonalizationPrompt(false);
-        setShowConsentModal(false);
         fetchCommentary();
-        return;
-      }
-
-      if (skipPersonalizationPrompt) {
-        setShowPersonalizationPrompt(false);
-        setShowConsentModal(true);
-        return;
-      }
-
-      if (customizationStatus === 'not-set' || customizationStatus === 'locked') {
-        setShowPersonalizationPrompt(true);
       } else {
-        setShowConsentModal(true);
+        setShowPersonalizationPrompt(true);
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen, customizationStatus, skipPersonalizationPrompt, skipConsent]);
-
-  const handleConsentAccept = () => {
-    if (typeof window !== "undefined") {
-      localStorage.setItem(CONSENT_STORAGE_KEY, "true");
-      setHasConsent(true);
-      setShowConsentModal(false);
-      trackAIAnalysisRun();
-      fetchCommentary();
-    }
-  };
-
-  const handleConsentDecline = () => {
-    setShowConsentModal(false);
-    onClose();
-  };
+  }, [isOpen, customizationStatus, skipPersonalizationPrompt]);
 
   const fetchCommentary = async () => {
     console.log('[fetchCommentary] Starting...');
@@ -798,13 +757,7 @@ Keep your response concise (400-600 words), educational, and reassuring where ap
       : null;
   }
 
-  const modalContent = showConsentModal ? (
-    <NilAIConsentModal
-      isOpen={showConsentModal}
-      onAccept={handleConsentAccept}
-      onDecline={handleConsentDecline}
-    />
-  ) : (
+  const modalContent = (
     <div className="modal-overlay" onClick={onClose}>
       <div
         className="modal-dialog commentary-modal"

--- a/app/components/MenuBar.tsx
+++ b/app/components/MenuBar.tsx
@@ -426,13 +426,10 @@ export default function MenuBar() {
           </Link>
           <Link
             href="/overview-report"
-            className={isOverviewReportActive ? "nav-link active nav-premium-link" : "nav-link nav-premium-link"}
+            className={isOverviewReportActive ? "nav-link active" : "nav-link"}
             style={getNavLinkStyle(isOverviewReportActive)}
           >
-            <span className="nav-link-content">
-              Analyze
-              <span className="nav-premium-badge">Premium</span>
-            </span>
+            Analyze
           </Link>
         </nav>
       </div>

--- a/app/components/MenuBar.tsx
+++ b/app/components/MenuBar.tsx
@@ -312,7 +312,7 @@ export default function MenuBar() {
     textDecoration: "none",
     color: active ? "var(--primary-color, #667eea)" : "inherit",
     borderBottom: active ? "2px solid var(--primary-color, #667eea)" : "none",
-    fontWeight: active ? 600 : 400
+    fontWeight: active ? 700 : 500
   });
 
   const isDNAChatActive = pathname === "/dna-chat" || pathname === "/llm-chat";

--- a/app/components/PremiumFeatureHeader.tsx
+++ b/app/components/PremiumFeatureHeader.tsx
@@ -9,11 +9,15 @@ import { trackOverviewReportTabViewed } from "@/lib/analytics";
 type PremiumFeatureHeaderProps = {
   featureName: string;
   description: string;
+  gateTitle?: string;       // overrides default "featureName is a premium tab" / "Premium subscription required"
+  gateDescription?: string; // overrides default "Subscribe for $4.99/month to access featureName."
 };
 
 export default function PremiumFeatureHeader({
   featureName,
   description,
+  gateTitle,
+  gateDescription,
 }: PremiumFeatureHeaderProps) {
   const {
     isAuthenticated,
@@ -60,7 +64,7 @@ export default function PremiumFeatureHeader({
         {!isAuthenticated && !hasPromoAccess ? (
           <div className="auth-prompt-inline">
             <div className="subscription-message">
-              <strong>{featureName} is a premium tab</strong>
+              <strong>{gateTitle ?? `${featureName} is a premium tab`}</strong>
               <span>{description}</span>
             </div>
             <button
@@ -73,8 +77,8 @@ export default function PremiumFeatureHeader({
         ) : !hasPremiumAccess ? (
           <div className="subscription-prompt-inline">
             <div className="subscription-message">
-              <strong>Premium subscription required</strong>
-              <span>Subscribe for $4.99/month to access {featureName}.</span>
+              <strong>{gateTitle ?? 'Premium subscription required'}</strong>
+              <span>{gateDescription ?? `Subscribe for $4.99/month to access ${featureName}.`}</span>
             </div>
             <Link href="/subscribe" className="subscribe-button">
               Subscribe

--- a/app/dna-chat/page.tsx
+++ b/app/dna-chat/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import MenuBar from "../components/MenuBar";
+import PremiumFeatureHeader from "../components/PremiumFeatureHeader";
 import Footer from "../components/Footer";
 import LLMChatInline from "../components/LLMChatInline";
 import GuidedTour from "../components/GuidedTour";
@@ -175,6 +176,12 @@ export default function DNAChatPage() {
     <div className="app-container">
       <MenuBar />
       <main className="page premium-feature-page dna-chat-page">
+        <PremiumFeatureHeader
+          featureName="DNA Chat Research"
+          description="Send and chat are free. The Research feature requires a subscription."
+          gateTitle="Research requires a subscription"
+          gateDescription="Subscribe for $4.99/month to unlock the Research feature in DNA Chat."
+        />
         <section className="premium-section premium-feature-section dna-chat-section">
           {(sampleLoad.status === "downloading" || sampleLoad.status === "loading") && (
             <div className="dna-chat-sample-notice loading">

--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -35,7 +35,7 @@ export default function ExplorePage() {
   const router = useRouter();
   const { savedResults } = useResults();
   const { isUploaded } = useGenotype();
-  const { customization } = useCustomization();
+  const { customization, status: customizationStatus } = useCustomization();
   const [navigating, setNavigating] = useState(false);
   const [shownIncreased, setShownIncreased] = useState(5);
 
@@ -204,6 +204,37 @@ export default function ExplorePage() {
                     )}
                   </div>
                 )}
+              </div>
+            )}
+
+            {/* Personalization notice */}
+            {customizationStatus === 'not-set' && (
+              <div className="explore-personalization-notice">
+                <span className="explore-personalization-notice-icon">🧬</span>
+                <div>
+                  <strong>Add your health history for personalized results.</strong>{' '}
+                  The "Based on your health history" section matches your genetic results to conditions you or your family have. Click <strong>Personalize</strong> in the menu above to set it up.
+                </div>
+              </div>
+            )}
+            {customizationStatus === 'locked' && (
+              <div className="explore-personalization-notice">
+                <span className="explore-personalization-notice-icon">🔒</span>
+                <div>
+                  <strong>Unlock personalization to see condition-matched results.</strong>{' '}
+                  Your health history is saved but locked. Click <strong>Personalize</strong> in the menu above and enter your password to unlock it.
+                </div>
+              </div>
+            )}
+            {customizationStatus === 'unlocked' && healthMatches.length === 0 &&
+              (customization?.personalConditions?.length ?? 0) === 0 &&
+              (customization?.familyConditions?.length ?? 0) === 0 && (
+              <div className="explore-personalization-notice">
+                <span className="explore-personalization-notice-icon">🧬</span>
+                <div>
+                  <strong>No health conditions added yet.</strong>{' '}
+                  Add personal and family conditions in <strong>Personalize</strong> to see traits matched to your health history.
+                </div>
               </div>
             )}
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -2568,6 +2568,31 @@ tbody tr:hover {
 .explore-highlight-item--neutral:hover { background: rgba(0, 0, 0, 0.06); }
 .explore-highlight-item--neutral .explore-highlight-score { color: #6b7280; }
 
+/* Personalization notice */
+.explore-personalization-notice {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  background: var(--surface-elevated, rgba(255,255,255,0.04));
+  border: 1px solid var(--border-subtle, rgba(255,255,255,0.1));
+  border-radius: 8px;
+  padding: 0.875rem 1rem;
+  margin-bottom: 1.5rem;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.explore-personalization-notice-icon {
+  font-size: 1.1rem;
+  flex-shrink: 0;
+  margin-top: 0.05rem;
+}
+
+.explore-personalization-notice strong {
+  color: var(--text-primary, inherit);
+}
+
 /* Health history section */
 .explore-health-section {
   margin-bottom: 1.5rem;

--- a/app/globals.css
+++ b/app/globals.css
@@ -3634,8 +3634,9 @@ details[open] .summary-arrow {
   }
 
   .nav-link {
-    padding: 0.35rem 0.25rem !important;
-    font-size: 0.75rem;
+    padding: 0.35rem 0.5rem !important;
+    font-size: 0.875rem;
+    font-weight: 500;
   }
 
   .nav-premium-badge {

--- a/app/globals.css
+++ b/app/globals.css
@@ -4907,6 +4907,55 @@ details[open] .summary-arrow {
   cursor: not-allowed;
 }
 
+.chat-research-button {
+  padding: 0 1.25rem;
+  background: #7c3aed;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  white-space: nowrap;
+}
+
+.chat-research-button:hover:not(:disabled) {
+  background: #6d28d9;
+  transform: translateY(-1px);
+}
+
+.chat-research-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.chat-research-premium-badge {
+  display: inline-block;
+  margin-left: 0.4rem;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 3px;
+  padding: 0.1em 0.35em;
+  vertical-align: middle;
+}
+
+.chat-research-hint {
+  margin: 0.3rem 0 0;
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+  text-align: right;
+}
+
+.chat-dynamic-widget {
+  display: flex;
+  align-items: center;
+  margin-right: auto;
+}
+
 .chat-footer-disclaimer {
   padding: 0.5rem 1.5rem;
   background: rgba(245, 158, 11, 0.05);
@@ -5561,6 +5610,30 @@ details[open] .summary-arrow {
 }
 
 .ai-chat-inline .chat-send-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.ai-chat-inline .chat-research-button {
+  padding: 0.6rem 1.25rem;
+  background: #7c3aed;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  white-space: nowrap;
+}
+
+.ai-chat-inline .chat-research-button:hover:not(:disabled) {
+  background: #6d28d9;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(124, 58, 237, 0.3);
+}
+
+.ai-chat-inline .chat-research-button:disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
@@ -6520,7 +6593,8 @@ details[open] .summary-arrow {
 }
 
 .dna-chat-section .ai-chat-inline .chat-attachment-button,
-.dna-chat-section .ai-chat-inline .chat-send-button {
+.dna-chat-section .ai-chat-inline .chat-send-button,
+.dna-chat-section .ai-chat-inline .chat-research-button {
   min-height: 38px;
   border-radius: 6px;
   font-size: 0.86rem;
@@ -6531,6 +6605,11 @@ details[open] .summary-arrow {
 }
 
 .dna-chat-section .ai-chat-inline .chat-send-button {
+  min-width: 106px;
+  padding: 0.55rem 1rem;
+}
+
+.dna-chat-section .ai-chat-inline .chat-research-button {
   min-width: 106px;
   padding: 0.55rem 1rem;
 }
@@ -6860,13 +6939,23 @@ details[open] .summary-arrow {
 }
 
 .dna-chat-section .ai-chat-inline .chat-attachment-button,
-.dna-chat-section .ai-chat-inline .chat-send-button {
+.dna-chat-section .ai-chat-inline .chat-send-button,
+.dna-chat-section .ai-chat-inline .chat-research-button {
   min-height: 40px;
   font-weight: 800;
 }
 
 .dna-chat-section .ai-chat-inline .chat-send-button {
   background: #0f766e;
+}
+
+.dna-chat-section .ai-chat-inline .chat-research-button {
+  background: #7c3aed;
+}
+
+.dna-chat-section .ai-chat-inline .chat-research-button:hover:not(:disabled) {
+  background: #6d28d9;
+  box-shadow: 0 8px 20px rgba(124, 58, 237, 0.24);
 }
 
 .dna-chat-section .ai-chat-inline .chat-send-button:hover:not(:disabled) {

--- a/app/globals.css
+++ b/app/globals.css
@@ -4943,17 +4943,32 @@ details[open] .summary-arrow {
   vertical-align: middle;
 }
 
-.chat-research-hint {
-  margin: 0.3rem 0 0;
-  font-size: 0.78rem;
-  color: var(--text-secondary);
-  text-align: right;
+.chat-input-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.35rem 1.5rem 0.5rem;
+  gap: 1rem;
+  border-top: 1px solid var(--border-color);
 }
 
 .chat-dynamic-widget {
   display: flex;
   align-items: center;
-  margin-right: auto;
+  flex-shrink: 0;
+}
+
+.chat-research-hint {
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+  text-align: right;
+  margin: 0;
+}
+
+.chat-welcome-prompt {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  margin: 0 0 0.75rem;
 }
 
 .chat-footer-disclaimer {
@@ -6461,11 +6476,18 @@ details[open] .summary-arrow {
   overflow-y: auto;
   padding: 0.65rem 1rem;
   background: var(--primary-bg);
+  display: flex;
+  flex-direction: column;
 }
 
 .dna-chat-section .chat-welcome {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
   max-width: 1040px;
   margin: 0 auto;
+  width: 100%;
   padding: 0.25rem 0;
   text-align: left;
 }
@@ -6617,6 +6639,21 @@ details[open] .summary-arrow {
 .dna-chat-section .chat-footer-disclaimer {
   padding: 0.35rem 0.85rem;
   font-size: 0.68rem;
+}
+
+.dna-chat-section .chat-input-footer {
+  padding: 0.3rem 0.85rem 0.4rem;
+  border-top: 1px solid rgba(15, 118, 110, 0.12);
+  background: rgba(248, 250, 252, 0.6);
+}
+
+.dna-chat-section .chat-research-hint {
+  font-size: 0.74rem;
+}
+
+.dna-chat-section .chat-welcome-prompt {
+  font-size: 0.85rem;
+  margin-bottom: 0.6rem;
 }
 
 @media (max-width: 900px) {

--- a/app/landing-client.tsx
+++ b/app/landing-client.tsx
@@ -56,7 +56,7 @@ const featureCopy = [
   {
     label: "Analyze",
     href: "/overview-report",
-    text: "Generate AI-written reports from your full set of results. Reports find patterns, connect findings to your health history, and build a picture of your genetic biology. Premium feature.",
+    text: "Generate AI-written reports from your full set of results. Reports find patterns, connect findings to your health history, and build a picture of your genetic biology. The Health Insights report is free. Additional reports require a subscription.",
   },
   {
     label: "Privacy first",

--- a/app/landing-client.tsx
+++ b/app/landing-client.tsx
@@ -35,31 +35,34 @@ function formatBytes(bytes: number): string {
 
 const SCHEDULE_CALL_URL = "https://calendar.app.google/eVDN4d44GreUjR8p8";
 
+const PRIVACY_POLICY_URL = "https://monadicdna.com/privacy";
+
 const featureCopy = [
   {
     label: "Explore",
     href: "/explore",
-    text: "Explore your results trait by trait. Browse elevated and protective associations ranked by effect size, and see which traits connect to conditions in your personal and family health history.",
+    text: "Get an overview of what your results actually mean. See your strongest genetic signals, both elevated risks and protective findings, and find which ones connect to conditions in your personal or family health history.",
   },
   {
     label: "DNA Chat",
     href: "/dna-chat",
-    text: "Ask questions about your genetic results in plain English. Get explanations of specific traits, genes, and what population studies say about your variants.",
+    text: "Ask questions about your genetic data in plain English. Get clear explanations of specific findings, genes, and what the research says. It works like a conversation with a knowledgeable friend.",
   },
   {
     label: "Browse",
     href: "/browse",
-    text: "Browse studies from the GWAS Catalog with advanced filtering by trait, sample size, and significance. View a heatmap of your SNP matches across selected studies.",
+    text: "Search and filter thousands of genetic research studies. See which ones matched your DNA, how strong the effect is, and read the published science behind each result.",
   },
   {
     label: "Analyze",
     href: "/overview-report",
-    text: "Generate AI-written reports that synthesize patterns across your results, surface hypotheses about your biology, and connect findings to your health history. Premium feature.",
+    text: "Generate AI-written reports from your full set of results. Reports find patterns, connect findings to your health history, and build a picture of your genetic biology. Premium feature.",
   },
   {
     label: "Privacy first",
-    href: null,
-    text: "Your DNA stays in your browser. We do not store, transmit, or sell your raw genetic data. AI runs in Trusted Execution Environments for maximum anonymity.",
+    href: PRIVACY_POLICY_URL,
+    text: "Your DNA never leaves your device. We don't store, share, or sell your genetic data. All AI analysis runs in a private computing environment so your data stays yours.",
+    external: true,
   },
 ];
 
@@ -164,9 +167,15 @@ export default function LandingClient() {
               <p key={item.label}>
                 <span>
                   {item.href ? (
-                    <Link href={item.href} style={{ color: 'inherit', textDecoration: 'none' }}>
-                      {item.label}
-                    </Link>
+                    item.external ? (
+                      <a href={item.href} target="_blank" rel="noreferrer" style={{ color: 'inherit', textDecoration: 'none' }}>
+                        {item.label}
+                      </a>
+                    ) : (
+                      <Link href={item.href} style={{ color: 'inherit', textDecoration: 'none' }}>
+                        {item.label}
+                      </Link>
+                    )
                   ) : (
                     item.label
                   )}

--- a/app/landing-client.tsx
+++ b/app/landing-client.tsx
@@ -162,6 +162,43 @@ export default function LandingClient() {
         <div className="landing-home-copy">
           <h1 style={{ maxWidth: 'none' }}>Understand your DNA without giving it away.</h1>
 
+          <p style={{ marginTop: '0.5rem', marginBottom: '1.5rem', fontSize: '1.05rem', color: 'var(--text-secondary)' }}>
+            Upload your DNA file or try it now with sample data, free.
+          </p>
+
+          {error && <p className="landing-upload-error">{error}</p>}
+
+          <div style={{ marginBottom: '2rem' }}>
+            <button
+              className="primary-button"
+              onClick={loadSampleData}
+              disabled={sampleStatus === "downloading" || sampleStatus === "loading"}
+              style={{ fontSize: '1rem', padding: '0.75rem 2rem' }}
+            >
+              {sampleLabel}
+            </button>
+            {sampleProgressText && (
+              <p style={{ marginTop: '0.5rem', fontSize: '0.82rem', color: 'var(--text-secondary)' }}>
+                {sampleProgressText}
+              </p>
+            )}
+            {sampleError && (
+              <p style={{ marginTop: '0.5rem', fontSize: '0.82rem', color: 'var(--error)' }}>{sampleError}</p>
+            )}
+            <p style={{ marginTop: '0.6rem', fontSize: '0.82rem', color: 'var(--text-secondary)' }}>
+              No DNA file needed. Your data never leaves your device.{' '}
+              <a
+                href={SCHEDULE_CALL_URL}
+                target="_blank"
+                rel="noreferrer"
+                style={{ color: 'var(--accent-blue)', textDecoration: 'none' }}
+                onClick={() => trackGetStartedClicked("schedule_video_call")}
+              >
+                Need help? Book a free call.
+              </a>
+            </p>
+          </div>
+
           <div className="landing-home-explainer" aria-label="Monadic DNA Explorer features" style={{ maxWidth: 'none' }}>
             {featureCopy.map((item) => (
               <p key={item.label}>
@@ -184,45 +221,6 @@ export default function LandingClient() {
               </p>
             ))}
           </div>
-
-          {error && <p className="landing-upload-error">{error}</p>}
-
-          <div style={{ marginTop: '1.5rem' }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-              <button
-                className="secondary-button"
-                onClick={loadSampleData}
-                disabled={sampleStatus === "downloading" || sampleStatus === "loading"}
-                style={{ fontSize: '0.85rem' }}
-              >
-                {sampleLabel}
-              </button>
-              <span style={{ fontSize: '0.85rem', color: 'var(--text-secondary)' }}>
-                No DNA file? Load an example to explore the app.
-              </span>
-            </div>
-            {sampleProgressText && (
-              <p style={{ marginTop: '0.4rem', fontSize: '0.8rem', color: 'var(--text-secondary)' }}>
-                {sampleProgressText}
-              </p>
-            )}
-            {sampleError && (
-              <p style={{ marginTop: '0.4rem', fontSize: '0.8rem', color: 'var(--error)' }}>{sampleError}</p>
-            )}
-          </div>
-
-          <p style={{ marginTop: '1rem', fontSize: '0.85rem', color: 'var(--text-secondary)' }}>
-            New to the app?{' '}
-            <a
-              href={SCHEDULE_CALL_URL}
-              target="_blank"
-              rel="noreferrer"
-              style={{ color: 'var(--accent-blue)', textDecoration: 'none' }}
-              onClick={() => trackGetStartedClicked("schedule_video_call")}
-            >
-              Book a free help call.
-            </a>
-          </p>
         </div>
       </section>
     </main>

--- a/app/overview-report/page.tsx
+++ b/app/overview-report/page.tsx
@@ -43,6 +43,7 @@ export default function OverviewReportPage() {
     trackOverviewReportViewed();
   }, []);
 
+
   useEffect(() => {
     if (!hasCompletedTour(overviewReportTour.id)) {
       setTourOpen(true);
@@ -67,7 +68,7 @@ export default function OverviewReportPage() {
   };
 
   const handleGenerateHealthReport = () => {
-    if (!hasResults || !requirePremium()) return;
+    if (!hasResults) return;
     setShowHealthReportModal(true);
   };
 
@@ -84,10 +85,12 @@ export default function OverviewReportPage() {
   return (
     <div className="app-container">
       <MenuBar />
-      <main className="page premium-feature-page">
+      <main className="page">
         <PremiumFeatureHeader
-          featureName="Overview Report"
-          description="Generate a synthesized report across your saved genetic results."
+          featureName="Analyze"
+          description="Health Insights is free. Healthspan, Top Traits, and Overview reports require a subscription."
+          gateTitle="Some reports require a subscription"
+          gateDescription="Subscribe for $4.99/month to access Healthspan, Top Traits, and Overview reports."
         />
         <div style={{ textAlign: "right", padding: "0 1rem" }}>
           <button className="tour-trigger-link" onClick={() => setTourOpen(true)}>
@@ -101,7 +104,6 @@ export default function OverviewReportPage() {
             <div>
               <div className="premium-feature-title-row">
                 <h2>Overview Report</h2>
-                <span className="premium-tab-badge">Premium</span>
               </div>
               <p>
                 Turn your saved analysis results into a concise AI-generated
@@ -145,6 +147,7 @@ export default function OverviewReportPage() {
               <h3>
                 Healthspan Report
                 <span className="experimental-badge" style={{ marginLeft: '0.5rem' }}>New</span>
+                <span className="premium-tab-badge" style={{ marginLeft: '0.5rem' }}>Premium</span>
               </h3>
               <p>
                 Organizes your associations by healthspan domain: cardiovascular, metabolic, neurological, immune, musculoskeletal, and cancer susceptibility. Synthesizes patterns within and across domains.
@@ -170,6 +173,7 @@ export default function OverviewReportPage() {
               <h3>
                 Top Traits Report
                 <span className="experimental-badge" style={{ marginLeft: '0.5rem' }}>New</span>
+                <span className="premium-tab-badge" style={{ marginLeft: '0.5rem' }}>Premium</span>
               </h3>
               <p>
                 Takes your 100 strongest genetic associations by effect size and synthesizes what they reveal about your biology. Good starting point if you have not added health history yet.
@@ -195,6 +199,7 @@ export default function OverviewReportPage() {
               <h3>
                 Comprehensive Overview Report
                 <span className="experimental-badge" style={{ marginLeft: '0.5rem' }}>Experimental</span>
+                <span className="premium-tab-badge" style={{ marginLeft: '0.5rem' }}>Premium</span>
               </h3>
               <p>
                 Analyzes all your saved genetic results across categories: health, lifestyle, appearance, personality, and more. Works best after running broad analysis. Currently under development.

--- a/lib/research-service.ts
+++ b/lib/research-service.ts
@@ -1,0 +1,158 @@
+import { callLLM, callLLMStream, LLMMessage } from './llm-client';
+import { SavedResult } from './results-manager';
+
+export type ResearchAngle = { keyword: string; resultsCount: number };
+
+const ITERATIONS = 10;
+const RAG_LIMIT = 100;
+
+function formatRiskScore(score: number, level: string, effectType?: 'OR' | 'beta'): string {
+  if (level === 'neutral') return effectType === 'beta' ? 'baseline' : '1.0x';
+  if (effectType === 'beta') return `β=${score >= 0 ? '+' : ''}${score.toFixed(3)} units`;
+  return `${score.toFixed(2)}x`;
+}
+
+function formatResults(results: SavedResult[]): string {
+  return results
+    .map((r, idx) =>
+      `${idx + 1}. ${r.traitName} (${r.studyTitle}):
+   - Your genotype: ${r.userGenotype}
+   - Risk allele: ${r.riskAllele}
+   - Risk score: ${formatRiskScore(r.riskScore, r.riskLevel, r.effectType)} (${r.riskLevel})
+   - SNP: ${r.matchedSnp}`
+    )
+    .join('\n\n');
+}
+
+export async function* runResearchPipeline(
+  query: string,
+  customizationSummary: string,
+  totalResults: number,
+  getTopResultsByRelevance: (q: string, limit: number) => Promise<SavedResult[]>,
+  onStatus: (status: string) => void,
+  llmDescription: string,
+  onMeta?: (angles: ResearchAngle[]) => void,
+): AsyncGenerator<string> {
+  // Step 1: Extract keyword angles
+  onStatus('Extracting research angles...');
+
+  const keywordMessages: LLMMessage[] = [
+    {
+      role: 'system',
+      content: `You extract GWAS database search keywords from a user's question about their genetics.
+
+RULES:
+- Output exactly ${ITERATIONS} keywords or short phrases, one per line, no numbering, no explanation.
+- Keywords must reflect the TOPIC of the question — the biological traits, phenotypes, or mechanisms being asked about.
+- Do NOT use the user's medical conditions as keywords unless the question is directly asking about those conditions.
+- The user context is provided only to help you pick the most relevant angles within the question's topic. It must not redirect the keywords toward unrelated health conditions.
+- Be specific. "Bitter taste receptor TAS2R" is better than "taste preferences".
+
+EXAMPLE: If the question is "What foods will I like?" extract keywords about food preference genetics (taste receptors, flavor perception, olfaction, dietary patterns, food aversion). NOT about diabetes or autoimmune disease.`,
+    },
+    {
+      role: 'user',
+      content: `User question: "${query}"\n\nUser context (for prioritization only, do not redirect keywords):\n${customizationSummary || 'No personalization set.'}`,
+    },
+  ];
+
+  const keywordResponse = await callLLM(keywordMessages, { maxTokens: 150, temperature: 0.5 });
+
+  const keywords = keywordResponse.content
+    .split('\n')
+    .map(k => k.trim())
+    .filter(k => k.length > 0)
+    .slice(0, ITERATIONS);
+
+  if (keywords.length === 0) keywords.push(query);
+
+  // Step 2: Sequential RAG + focused analysis for each angle (avoids hammering nilAI)
+  const analyses: { keyword: string; analysis: string; resultsCount: number }[] = [];
+
+  for (let i = 0; i < keywords.length; i++) {
+    const keyword = keywords[i];
+    onStatus(`Angle ${i + 1}/${keywords.length}: ${keyword}...`);
+
+    const results = await getTopResultsByRelevance(keyword, RAG_LIMIT);
+
+    if (results.length === 0) {
+      analyses.push({ keyword, analysis: 'No relevant findings for this angle.', resultsCount: 0 });
+      continue;
+    }
+
+    const analysisMessages: LLMMessage[] = [
+      {
+        role: 'system',
+        content: `You analyze GWAS genetic findings for a specific research angle. ${llmDescription}
+
+USER CONTEXT:
+${customizationSummary || 'No personalization set.'}
+
+ORIGINAL USER QUESTION: "${query}"
+
+RESEARCH ANGLE: "${keyword}"
+
+GWAS FINDINGS:
+${formatResults(results)}
+
+Write a focused 150-word analysis of what these findings mean for this user, specific to the "${keyword}" angle. Reference actual findings by trait name and OR/beta values. Be concrete and personalized. No disclaimers needed here.`,
+      },
+      {
+        role: 'user',
+        content: `Analyze the "${keyword}" angle.`,
+      },
+    ];
+
+    const response = await callLLM(analysisMessages, { maxTokens: 350, temperature: 0.6 });
+    analyses.push({ keyword, analysis: response.content, resultsCount: results.length });
+  }
+
+  onMeta?.(analyses.map(a => ({ keyword: a.keyword, resultsCount: a.resultsCount })));
+
+  // Step 3: Stream comprehensive synthesis
+  onStatus('Synthesizing findings...');
+
+  const analysesText = analyses
+    .map(a => `**Angle: ${a.keyword}** (${a.resultsCount} studies)\n${a.analysis}`)
+    .join('\n\n');
+
+  const synthesisMessages: LLMMessage[] = [
+    {
+      role: 'system',
+      content: `You synthesize multi-angle genetic research into a comprehensive personalized answer. ${llmDescription}
+
+USER CONTEXT:
+${customizationSummary || 'No personalization set.'}
+
+Total results in user profile: ${totalResults.toLocaleString()}
+
+RESEARCH ANALYSES (${analyses.length} angles):
+${analysesText}
+
+Synthesize these analyses into a comprehensive answer to the user's question. Identify patterns across angles, highlight convergent findings, note what stands out given the user's context. Use the standard structure: overview, genetic landscape, personal implications, action steps. Target 600-900 words. Plain language. Complete your full response.
+
+GWAS results show statistical associations at the population level, not deterministic outcomes. Educational purposes only.
+
+After the response, append exactly this block:
+
+FOLLOWUP:
+- [question from the user's perspective connecting a finding directly to their personal situation]
+- [question digging deeper on the most impactful finding across the analyses]
+- [question connecting two of the research angles or asking how they interact]`,
+    },
+    {
+      role: 'user',
+      content: query,
+    },
+  ];
+
+  const stream = callLLMStream(synthesisMessages, {
+    maxTokens: 3000,
+    temperature: 0.7,
+    reasoningEffort: 'medium',
+  });
+
+  for await (const chunk of stream) {
+    yield chunk;
+  }
+}


### PR DESCRIPTION
# Summary

- Adds an agentic **Research** feature to DNA Chat (premium gated)
- Restructures the paywall: Health Insights Report is now free, Research in Chat is gated
- Removes per-page Premium branding in favor of per-feature labeling
- Improves the home page CTA and mobile nav legibility

---

## Research pipeline (new)

`lib/research-service.ts` exports `runResearchPipeline`, an async generator that runs a three-phase pipeline:

1. **Keyword extraction** — sends the user's query plus their personalization summary to the LLM and asks for 10 research angles (one keyword per line). The prompt explicitly prevents the model from anchoring on the user's health conditions unless the question is directly about those conditions.
2. **Sequential RAG + analysis** — for each keyword, fetches up to 100 top results via `getTopResultsByRelevance`, then calls the LLM for a focused ~150-word analysis. Runs sequentially rather than in parallel to avoid nilAI 429 rate-limit cascades.
3. **Streaming synthesis** — feeds all 10 analyses back to the LLM and streams a comprehensive 600-900 word answer. Yields chunks to the caller as they arrive.

The function accepts an `onMeta` callback that receives `ResearchAngle[]` (keyword + results count per angle) after the analysis phase, before synthesis begins.

**DNA Chat integration** (`app/components/LLMChatInline.tsx`):
- `handleResearch()` calls `requirePremium()` (same gate pattern as Analyze reports) then streams from the pipeline into the assistant message bubble
- `buildUserContext()` helper extracted from `handleSendMessage` and shared with `handleResearch` to avoid duplication
- `Message` type gains `researchMeta?: ResearchAngle[]`, used to render a collapsible "Researched N angles" panel below each research response
- Research button sits next to Send in the input footer; both share `isLoading` so only one can run at a time
- Loading status cycles through "Extracting research angles...", "Angle N/10: keyword...", "Synthesizing findings..."

---

## Paywall restructure

**Health Insights Report** is now free. `handleGenerateHealthReport` no longer calls `requirePremium()`.

**Analyze page** (`app/overview-report/page.tsx`):
- Removed page-level "Premium" labeling from the h2 heading
- Added per-report `<span className="premium-tab-badge">Premium</span>` to Healthspan, Top Traits, and Comprehensive Overview headings
- `PremiumFeatureHeader` copy updated to reflect mixed free/premium content: "Health Insights is free. Healthspan, Top Traits, and Overview reports require a subscription."

**DNA Chat page** (`app/dna-chat/page.tsx`):
- Added `PremiumFeatureHeader` with Research-specific gate copy: "Research requires a subscription."

**`PremiumFeatureHeader` component**:
- Added optional `gateTitle` and `gateDescription` props so callers can override the default "premium tab" messaging without duplicating the component

**MenuBar** (`app/components/MenuBar.tsx`):
- Removed `nav-premium-link` class and `nav-premium-badge` span from the Analyze link

---

## NilAI consent modal removed

`NilAIConsentModal` is no longer shown before the first DNA Chat message. The consent gate has been replaced by the premium subscription check. All related state (`showConsentModal`, `hasConsent`, `CONSENT_STORAGE_KEY`), analytics calls (`trackAIConsentGiven`, `trackAIConsentDeclined`, `trackAIConsentModalShown`), and handler functions have been removed from `LLMChatInline`.

---

## Home page CTA

`app/landing-client.tsx`:
- "Try with sample data" button promoted from `secondary-button` to `primary-button` with larger padding
- Added subheading: "Upload your DNA file or try it now with sample data, free."
- Added reassurance copy below the button: "No DNA file needed. Your data never leaves your device."
- Feature list entry for Analyze updated to note which reports are free vs. premium

---

## Mobile nav legibility

- `getNavLinkStyle` in `MenuBar.tsx`: inactive links bumped from `fontWeight: 400` to `500`; active from `600` to `700`
- Mobile CSS for `.nav-link`: `font-size` raised from `0.75rem` to `0.875rem`; `font-weight: 500` added explicitly; horizontal padding increased slightly so links breathe without overflowing the row
