### PR TITLE
Subscription funnel improvements and study page SEO

### DIFF
--- a/app/components/LLMChatInline.tsx
+++ b/app/components/LLMChatInline.tsx
@@ -98,7 +98,6 @@ export default function AIChatInline({ initialInput }: { initialInput?: string }
 
   const requirePremium = (): boolean => {
     if (!hasPremiumAccess && !hasValidPromoAccess()) {
-      if (!isAuthenticated) { openAuthModal(); return false; }
       router.push('/subscribe');
       return false;
     }
@@ -692,9 +691,10 @@ Write questions from the user's perspective — as if the user is asking you. No
   };
 
   const handleResearch = async () => {
-    const query = inputValue.trim();
-    if (!query || isLoading) return;
+    if (isLoading) return;
     if (!requirePremium()) return;
+    const query = inputValue.trim();
+    if (!query) return;
 
     setInputValue('');
     setIsLoading(true);
@@ -1236,7 +1236,7 @@ Write questions from the user's perspective — as if the user is asking you. No
               <button
                 className="chat-research-button"
                 onClick={handleResearch}
-                disabled={isLoading || !inputValue.trim()}
+                disabled={isLoading || (hasPremiumAccess && !inputValue.trim())}
                 title="Searches 10 targeted keyword angles across your genetic data, then synthesizes findings into a comprehensive answer."
               >
                 {isLoading ? 'Thinking...' : 'Research'}

--- a/app/components/StudyNavButtons.tsx
+++ b/app/components/StudyNavButtons.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { useResults } from "./ResultsContext";
+
+export default function StudyNavButtons() {
+  const router = useRouter();
+  const { savedResults } = useResults();
+  const [totalStudies, setTotalStudies] = useState<number | null>(null);
+  const [navigating, setNavigating] = useState(false);
+
+  useEffect(() => {
+    if (savedResults.length > 0) return;
+    fetch("/api/studies?limit=1")
+      .then(r => r.json())
+      .then(data => { if (data.total) setTotalStudies(data.total); })
+      .catch(() => {});
+  }, [savedResults.length]);
+
+  const handleNextRandom = () => {
+    setNavigating(true);
+    if (savedResults.length > 0) {
+      const result = savedResults[Math.floor(Math.random() * savedResults.length)];
+      router.push(`/study/${result.studyId}`);
+    } else if (totalStudies !== null) {
+      router.push(`/study/${Math.floor(Math.random() * totalStudies) + 1}`);
+    }
+  };
+
+  const disabled = navigating || (savedResults.length === 0 && totalStudies === null);
+
+  return (
+    <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap", alignItems: "center" }}>
+      <Link href="/browse" style={{
+        display: "inline-block",
+        padding: "0.5rem 1rem",
+        backgroundColor: "#667eea",
+        color: "white",
+        textDecoration: "none",
+        borderRadius: "6px",
+        fontSize: "0.85rem",
+        fontWeight: 600,
+      }}>
+        ← Back to Browse
+      </Link>
+      <button
+        onClick={handleNextRandom}
+        disabled={disabled}
+        style={{
+          fontSize: "0.85rem",
+          padding: "0.5rem 1rem",
+          background: "linear-gradient(135deg, #667eea, #764ba2)",
+          border: "none",
+          color: "white",
+          borderRadius: "6px",
+          cursor: "pointer",
+          whiteSpace: "nowrap",
+          fontWeight: 600,
+          boxShadow: "0 2px 6px rgba(102,126,234,0.4)",
+          opacity: disabled ? 0.5 : 1,
+        }}
+      >
+        {navigating ? "Loading..." : "Next Random Study →"}
+      </button>
+    </div>
+  );
+}

--- a/app/components/StudyPersonalSection.tsx
+++ b/app/components/StudyPersonalSection.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useResults } from "./ResultsContext";
+import StudyPersonalResultBanner from "./StudyPersonalResultBanner";
+import StudyInlineAnalysis from "./StudyInlineAnalysis";
+
+type Props = {
+  studyId: number;
+  studyAccession: string | null;
+  snps: string | null;
+  traitName: string;
+  studyTitle: string;
+  riskAllele?: string | null;
+  orOrBeta?: string | null;
+  ciText?: string | null;
+  isAnalyzable: boolean;
+  nonAnalyzableReason?: string;
+  pubmedId?: string | null;
+  mappedGene?: string | null;
+  reportedTrait?: string | null;
+};
+
+export default function StudyPersonalSection({
+  studyId,
+  studyAccession,
+  snps,
+  traitName,
+  studyTitle,
+  riskAllele,
+  orOrBeta,
+  ciText,
+  isAnalyzable,
+  nonAnalyzableReason,
+  pubmedId,
+  mappedGene,
+  reportedTrait,
+}: Props) {
+  const { hasResult, getResult } = useResults();
+  const result = getResult(studyId);
+
+  return (
+    <>
+      <StudyPersonalResultBanner
+        studyId={studyId}
+        studyAccession={studyAccession}
+        snps={snps}
+        traitName={traitName}
+        studyTitle={studyTitle}
+        riskAllele={riskAllele}
+        orOrBeta={orOrBeta}
+        ciText={ciText}
+        isAnalyzable={isAnalyzable}
+        nonAnalyzableReason={nonAnalyzableReason}
+      />
+      {hasResult(studyId) && result && (
+        <StudyInlineAnalysis
+          result={result}
+          pubmedId={pubmedId}
+          mappedGene={mappedGene}
+          reportedTrait={reportedTrait}
+        />
+      )}
+    </>
+  );
+}

--- a/app/overview-report/page.tsx
+++ b/app/overview-report/page.tsx
@@ -55,7 +55,6 @@ export default function OverviewReportPage() {
 
   const requirePremium = () => {
     if (!hasPremiumAccess && !hasValidPromoAccess()) {
-      if (!isAuthenticated) { openAuthModal(); return false; }
       router.push('/subscribe');
       return false;
     }

--- a/app/study/[id]/page.tsx
+++ b/app/study/[id]/page.tsx
@@ -1,154 +1,53 @@
-"use client";
-
-import { useEffect, useState } from "react";
-import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
+import { notFound } from "next/navigation";
 import MenuBar from "../../components/MenuBar";
 import Footer from "../../components/Footer";
 import VariantChips from "../../components/VariantChips";
-import StudyPersonalResultBanner from "../../components/StudyPersonalResultBanner";
-import { useResults } from "../../components/ResultsContext";
-import StudyInlineAnalysis from "../../components/StudyInlineAnalysis";
+import StudyNavButtons from "../../components/StudyNavButtons";
+import StudyPersonalSection from "../../components/StudyPersonalSection";
+import { fetchStudyById } from "@/lib/study-service";
 
-type Study = {
-  id: number;
-  study_accession: string | null;
-  study: string | null;
-  disease_trait: string | null;
-  mapped_trait: string | null;
-  mapped_trait_uri: string | null;
-  mapped_gene: string | null;
-  first_author: string | null;
-  date: string | null;
-  journal: string | null;
-  pubmedid: string | null;
-  link: string | null;
-  initial_sample_size: string | null;
-  replication_sample_size: string | null;
-  p_value: string | null;
-  pvalue_mlog: string | null;
-  or_or_beta: string | null;
-  ci_text: string | null;
-  risk_allele_frequency: string | null;
-  strongest_snp_risk_allele: string | null;
-  snps: string | null;
-  sampleSize: number | null;
-  sampleSizeLabel: string;
-  pValueNumeric: number | null;
-  pValueLabel: string;
-  logPValue: number | null;
-  qualityFlags: Array<{ message: string; severity: string }>;
-  isLowQuality: boolean;
-  confidenceBand: "high" | "medium" | "low";
-  publicationDate: number | null;
-  isAnalyzable: boolean;
-  nonAnalyzableReason?: string;
-};
+function interpretSampleSize(n: number | null): string {
+  if (n === null) return "";
+  if (n >= 100000) return "Very large study";
+  if (n >= 10000) return "Large study";
+  if (n >= 1000) return "Mid-size study";
+  return "Smaller study";
+}
 
-export default function StudyDetailPage() {
-  const params = useParams();
-  const router = useRouter();
-  const studyId = params.id as string;
-  const [study, setStudy] = useState<Study | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const { savedResults, hasResult, getResult } = useResults();
-  const [totalStudies, setTotalStudies] = useState<number | null>(null);
-  const [navigating, setNavigating] = useState(false);
+function interpretPValue(logP: number | null): string {
+  if (logP === null) return "";
+  if (logP >= 10) return "Exceptionally strong evidence";
+  if (logP >= 7.3) return "Very strong evidence";
+  if (logP >= 5) return "Strong evidence";
+  if (logP >= 3) return "Moderate evidence";
+  return "Suggestive evidence";
+}
 
-  useEffect(() => {
-    if (savedResults.length > 0) return;
-    fetch("/api/studies?limit=1")
-      .then(r => r.json())
-      .then(data => { if (data.total) setTotalStudies(data.total); })
-      .catch(() => {});
-  }, [savedResults.length]);
+function interpretEffectSize(orBeta: string | null): string {
+  if (!orBeta) return "";
+  const val = parseFloat(orBeta);
+  if (isNaN(val)) return "";
+  if (val >= 2 || val <= 0.5) return "Large effect";
+  if (val >= 1.3 || val <= 0.77) return "Moderate effect";
+  if (val >= 1.1 || val <= 0.91) return "Subtle effect";
+  return "Very subtle effect";
+}
 
-  const handleNextRandom = () => {
-    setNavigating(true);
-    if (savedResults.length > 0) {
-      const result = savedResults[Math.floor(Math.random() * savedResults.length)];
-      router.push(`/study/${result.studyId}`);
-    } else if (totalStudies !== null) {
-      router.push(`/study/${Math.floor(Math.random() * totalStudies) + 1}`);
-    }
-  };
+function formatDisplayDate(dateStr: string): string {
+  const ts = Date.parse(dateStr);
+  if (Number.isNaN(ts)) return dateStr;
+  return new Date(ts).toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" });
+}
 
-  useEffect(() => {
-    const fetchStudy = async () => {
-      try {
-        setLoading(true);
-        setError(null);
+export default async function StudyDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const studyPk = parseInt(id);
 
-        // Fetch study by ID from the API
-        const response = await fetch(`/api/studies?id=${parseInt(studyId)}`);
+  if (isNaN(studyPk) || studyPk <= 0) notFound();
 
-        if (!response.ok) {
-          throw new Error('Failed to fetch study details');
-        }
-
-        const data = await response.json();
-
-        if (data.data && data.data.length > 0) {
-          setStudy(data.data[0]);
-        } else {
-          setError('Study not found');
-        }
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'An error occurred');
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    if (studyId) {
-      fetchStudy();
-    }
-  }, [studyId]);
-
-  if (loading) {
-    return (
-      <>
-        <div className="app-container">
-          <MenuBar />
-          <main className="page">
-            <div style={{ padding: "2rem", textAlign: "center" }}>
-              <p>Loading study details...</p>
-            </div>
-          </main>
-          <Footer />
-        </div>
-      </>
-    );
-  }
-
-  if (error || !study) {
-    return (
-      <>
-        <div className="app-container">
-          <MenuBar />
-          <main className="page">
-            <div style={{ padding: "2rem" }}>
-              <h2>Study Not Found</h2>
-              <p>{error || 'The requested study could not be found.'}</p>
-              <Link href="/browse" style={{
-                display: "inline-block",
-                marginTop: "1rem",
-                padding: "0.75rem 1.5rem",
-                backgroundColor: "#667eea",
-                color: "white",
-                textDecoration: "none",
-                borderRadius: "6px"
-              }}>
-                ← Back to Browse
-              </Link>
-            </div>
-          </main>
-          <Footer />
-        </div>
-      </>
-    );
-  }
+  const study = await fetchStudyById(studyPk);
+  if (!study) notFound();
 
   const reportedTrait = study.disease_trait?.trim() || null;
   const mappedTrait = study.mapped_trait?.trim() || null;
@@ -159,235 +58,181 @@ export default function StudyDetailPage() {
   const pubmedLink = study.pubmedid
     ? `https://pubmed.ncbi.nlm.nih.gov/${study.pubmedid}`
     : null;
-  const studyLink = gwasLink || study.link || pubmedLink;
-
-  const interpretSampleSize = (n: number | null): string => {
-    if (n === null) return "";
-    if (n >= 100000) return "Very large study";
-    if (n >= 10000) return "Large study";
-    if (n >= 1000) return "Mid-size study";
-    return "Smaller study";
-  };
-
-  const interpretPValue = (logP: number | null): string => {
-    if (logP === null) return "";
-    if (logP >= 10) return "Exceptionally strong evidence";
-    if (logP >= 7.3) return "Very strong evidence";
-    if (logP >= 5) return "Strong evidence";
-    if (logP >= 3) return "Moderate evidence";
-    return "Suggestive evidence";
-  };
-
-  const interpretEffectSize = (orBeta: string | null): string => {
-    if (!orBeta) return "";
-    const val = parseFloat(orBeta);
-    if (isNaN(val)) return "";
-    // OR interpretation
-    if (val >= 2 || val <= 0.5) return "Large effect";
-    if (val >= 1.3 || val <= 0.77) return "Moderate effect";
-    if (val >= 1.1 || val <= 0.91) return "Subtle effect";
-    return "Very subtle effect";
-  };
-
-  const navButtons = (
-    <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap", alignItems: "center" }}>
-      <Link href="/browse" style={{
-        display: "inline-block",
-        padding: "0.5rem 1rem",
-        backgroundColor: "#667eea",
-        color: "white",
-        textDecoration: "none",
-        borderRadius: "6px",
-        fontSize: "0.85rem",
-        fontWeight: 600,
-      }}>
-        ← Back to Browse
-      </Link>
-      <button
-        onClick={handleNextRandom}
-        disabled={navigating || (savedResults.length === 0 && totalStudies === null)}
-        style={{ fontSize: "0.85rem", padding: "0.5rem 1rem", background: "linear-gradient(135deg, #667eea, #764ba2)", border: "none", color: "white", borderRadius: "6px", cursor: "pointer", whiteSpace: "nowrap", fontWeight: 600, boxShadow: "0 2px 6px rgba(102,126,234,0.4)", opacity: (navigating || (savedResults.length === 0 && totalStudies === null)) ? 0.5 : 1 }}
-      >
-        {navigating ? "Loading..." : "Next Random Study →"}
-      </button>
-    </div>
-  );
 
   return (
-    <>
-      <div className="app-container">
-        <MenuBar />
-        <main className="page">
-          {/* Breadcrumb + top nav */}
-          <div style={{ padding: "1rem 0", display: "flex", alignItems: "center", justifyContent: "space-between", flexWrap: "wrap", gap: "0.75rem" }}>
-            <span style={{ fontSize: "0.9rem", color: "#666" }}>
-              <Link href="/" style={{ color: "#667eea", textDecoration: "none" }}>Home</Link>
-              {" > "}
-              <Link href="/browse" style={{ color: "#667eea", textDecoration: "none" }}>Browse</Link>
-              {" > "}
-              <span>Study {study.id}</span>
+    <div className="app-container">
+      <MenuBar />
+      <main className="page">
+        {/* Breadcrumb + top nav */}
+        <div style={{ padding: "1rem 0", display: "flex", alignItems: "center", justifyContent: "space-between", flexWrap: "wrap", gap: "0.75rem" }}>
+          <span style={{ fontSize: "0.9rem", color: "#666" }}>
+            <Link href="/" style={{ color: "#667eea", textDecoration: "none" }}>Home</Link>
+            {" > "}
+            <Link href="/browse" style={{ color: "#667eea", textDecoration: "none" }}>Browse</Link>
+            {" > "}
+            <span>Study {study.id}</span>
+          </span>
+          <StudyNavButtons />
+        </div>
+
+        {/* Study Header */}
+        <section className="study-header-card">
+          <div style={{ marginBottom: "0.75rem" }}>
+            <span style={{ display: "inline-block", fontSize: "1.1rem", fontWeight: 700, color: "#667eea", background: "rgba(102,126,234,0.1)", border: "1px solid rgba(102,126,234,0.25)", borderRadius: "6px", padding: "0.3rem 0.8rem", letterSpacing: "0.01em" }}>
+              {trait}
             </span>
-            {navButtons}
+          </div>
+          <h1 className="study-header-title">{study.study || "Untitled Study"}</h1>
+
+          <div className="study-header-meta">
+            {reportedTrait && mappedTrait && mappedTrait !== reportedTrait && (
+              <span className="study-meta-item"><strong>Reported trait:</strong> {reportedTrait}</span>
+            )}
+            {study.first_author && (
+              <span className="study-meta-item"><strong>Author:</strong> {study.first_author}</span>
+            )}
+            {study.date && (
+              <span className="study-meta-item"><strong>Date:</strong> {formatDisplayDate(study.date)}</span>
+            )}
+            {study.journal && (
+              <span className="study-meta-item"><strong>Journal:</strong> {study.journal}</span>
+            )}
+            {study.study_accession && (
+              <span className="study-meta-item"><strong>Accession:</strong> {study.study_accession}</span>
+            )}
+            {study.mapped_gene && (
+              <span className="study-meta-item"><strong>Gene:</strong> {study.mapped_gene}</span>
+            )}
           </div>
 
-          {/* Study Header */}
-          <section className="study-header-card">
-            <div style={{ marginBottom: "0.75rem" }}>
-              <span style={{ display: "inline-block", fontSize: "1.1rem", fontWeight: 700, color: "#667eea", background: "rgba(102,126,234,0.1)", border: "1px solid rgba(102,126,234,0.25)", borderRadius: "6px", padding: "0.3rem 0.8rem", letterSpacing: "0.01em" }}>
-                {trait}
+          <div className="study-header-links">
+            {gwasLink && (
+              <a href={gwasLink} target="_blank" rel="noopener noreferrer" className="study-ext-link study-ext-link--gwas">
+                <span className="study-ext-link-title">Source data →</span>
+                <span className="study-ext-link-desc">Full dataset on GWAS Catalog</span>
+              </a>
+            )}
+            {pubmedLink && (
+              <a href={pubmedLink} target="_blank" rel="noopener noreferrer" className="study-ext-link study-ext-link--pubmed">
+                <span className="study-ext-link-title">Research paper →</span>
+                <span className="study-ext-link-desc">Published article on PubMed</span>
+              </a>
+            )}
+          </div>
+        </section>
+
+        {/* Personal result banner + inline analysis (client-rendered, reads from browser) */}
+        <StudyPersonalSection
+          studyId={study.id}
+          studyAccession={study.study_accession}
+          snps={study.snps}
+          traitName={trait}
+          studyTitle={study.study || "Untitled study"}
+          riskAllele={study.strongest_snp_risk_allele}
+          orOrBeta={study.or_or_beta}
+          ciText={study.ci_text}
+          isAnalyzable={study.isAnalyzable}
+          nonAnalyzableReason={study.nonAnalyzableReason}
+          pubmedId={study.pubmedid}
+          mappedGene={study.mapped_gene}
+          reportedTrait={study.disease_trait}
+        />
+
+        {/* Study Details */}
+        <section className="study-details-card">
+          <div className="study-stats-grid">
+            {study.date && (
+              <div className="study-stat-tile">
+                <span className="sst-label">Published</span>
+                <span className="sst-value">{new Date(study.date).getFullYear()}</span>
+                <span className="sst-context">{study.journal || "Peer-reviewed"}</span>
+              </div>
+            )}
+            {study.sampleSize !== null && (
+              <div className="study-stat-tile">
+                <span className="sst-label">Participants</span>
+                <span className="sst-value">{study.sampleSizeLabel}</span>
+                <span className="sst-context">{interpretSampleSize(study.sampleSize)}</span>
+              </div>
+            )}
+            {study.pValueNumeric !== null && (
+              <div className="study-stat-tile" title="How statistically significant the finding is">
+                <span className="sst-label">P-value</span>
+                <span className="sst-value">{study.pValueLabel}</span>
+                <span className="sst-context">{interpretPValue(study.logPValue)}</span>
+              </div>
+            )}
+            {study.or_or_beta && (
+              <div className="study-stat-tile" title="How strongly this variant influences the trait">
+                <span className="sst-label">Effect size</span>
+                <span className="sst-value">
+                  {study.or_or_beta}
+                  {study.ci_text ? <span className="sst-ci"> {study.ci_text}</span> : null}
+                </span>
+                <span className="sst-context">{interpretEffectSize(study.or_or_beta)}</span>
+              </div>
+            )}
+            {study.risk_allele_frequency && (
+              <div className="study-stat-tile" title="How common this genetic variant is in the population">
+                <span className="sst-label">Variant frequency</span>
+                <span className="sst-value">{study.risk_allele_frequency}</span>
+                <span className="sst-context">In population</span>
+              </div>
+            )}
+            <div className="study-stat-tile">
+              <span className="sst-label">Confidence</span>
+              <span className="sst-value">
+                <span className={`quality-pill ${study.confidenceBand}`}>
+                  {study.confidenceBand === "high" ? "High" : study.confidenceBand === "medium" ? "Medium" : "Lower"}
+                </span>
+              </span>
+              <span className="sst-context">
+                {study.confidenceBand === "high" ? "Well-replicated" : study.confidenceBand === "medium" ? "Some caveats" : "Interpret carefully"}
               </span>
             </div>
-            <h1 className="study-header-title">{study.study || "Untitled Study"}</h1>
+          </div>
 
-            <div className="study-header-meta">
-              {reportedTrait && mappedTrait && mappedTrait !== reportedTrait && <span className="study-meta-item"><strong>Reported trait:</strong> {reportedTrait}</span>}
-              {study.first_author && <span className="study-meta-item"><strong>Author:</strong> {study.first_author}</span>}
-              {study.date && <span className="study-meta-item"><strong>Date:</strong> {new Date(study.date).toLocaleDateString()}</span>}
-              {study.journal && <span className="study-meta-item"><strong>Journal:</strong> {study.journal}</span>}
-              {study.study_accession && <span className="study-meta-item"><strong>Accession:</strong> {study.study_accession}</span>}
-              {study.mapped_gene && <span className="study-meta-item"><strong>Gene:</strong> {study.mapped_gene}</span>}
+          {study.snps && (
+            <div className="study-variants-row">
+              <span className="study-variants-label">Variants tested</span>
+              <VariantChips snps={study.snps} riskAllele={study.strongest_snp_risk_allele} />
             </div>
-
-            <div className="study-header-links">
-              {gwasLink && (
-                <a href={gwasLink} target="_blank" rel="noopener noreferrer" className="study-ext-link study-ext-link--gwas">
-                  <span className="study-ext-link-title">Source data →</span>
-                  <span className="study-ext-link-desc">Full dataset on GWAS Catalog</span>
-                </a>
-              )}
-              {pubmedLink && (
-                <a href={pubmedLink} target="_blank" rel="noopener noreferrer" className="study-ext-link study-ext-link--pubmed">
-                  <span className="study-ext-link-title">Research paper →</span>
-                  <span className="study-ext-link-desc">Published article on PubMed</span>
-                </a>
-              )}
-            </div>
-          </section>
-
-          {/* Personal Result Banner */}
-          <StudyPersonalResultBanner
-            studyId={study.id}
-            studyAccession={study.study_accession}
-            snps={study.snps}
-            traitName={trait}
-            studyTitle={study.study || "Untitled study"}
-            riskAllele={study.strongest_snp_risk_allele}
-            orOrBeta={study.or_or_beta}
-            ciText={study.ci_text}
-            isAnalyzable={study.isAnalyzable}
-            nonAnalyzableReason={study.nonAnalyzableReason}
-          />
-
-          {/* Inline LLM analysis when a saved result exists for this study */}
-          {hasResult(study.id) && getResult(study.id) && (
-            <StudyInlineAnalysis
-              result={getResult(study.id)!}
-              pubmedId={study.pubmedid}
-              mappedGene={study.mapped_gene}
-              reportedTrait={study.disease_trait}
-            />
           )}
 
-          {/* Study Details */}
-          <section className="study-details-card">
-            {/* Stat grid */}
-            <div className="study-stats-grid">
-              {study.date && (
-                <div className="study-stat-tile">
-                  <span className="sst-label">Published</span>
-                  <span className="sst-value">{new Date(study.date).getFullYear()}</span>
-                  <span className="sst-context">{study.journal || "Peer-reviewed"}</span>
-                </div>
+          {(study.initial_sample_size || study.replication_sample_size) && (
+            <div className="study-sample-detail">
+              {study.initial_sample_size && (
+                <p className="study-sample-row">
+                  <span className="study-sample-key">Initial sample</span>
+                  <span>{study.initial_sample_size}</span>
+                </p>
               )}
-              {study.sampleSize !== null && (
-                <div className="study-stat-tile">
-                  <span className="sst-label">Participants</span>
-                  <span className="sst-value">{study.sampleSizeLabel}</span>
-                  <span className="sst-context">{interpretSampleSize(study.sampleSize)}</span>
-                </div>
+              {study.replication_sample_size && (
+                <p className="study-sample-row">
+                  <span className="study-sample-key">Replication</span>
+                  <span>{study.replication_sample_size}</span>
+                </p>
               )}
-              {study.pValueNumeric !== null && (
-                <div className="study-stat-tile" title="How statistically significant the finding is">
-                  <span className="sst-label">P-value</span>
-                  <span className="sst-value">{study.pValueLabel}</span>
-                  <span className="sst-context">{interpretPValue(study.logPValue)}</span>
-                </div>
-              )}
-              {study.or_or_beta && (
-                <div className="study-stat-tile" title="How strongly this variant influences the trait">
-                  <span className="sst-label">Effect size</span>
-                  <span className="sst-value">
-                    {study.or_or_beta}
-                    {study.ci_text ? <span className="sst-ci"> {study.ci_text}</span> : null}
-                  </span>
-                  <span className="sst-context">{interpretEffectSize(study.or_or_beta)}</span>
-                </div>
-              )}
-              {study.risk_allele_frequency && (
-                <div className="study-stat-tile" title="How common this genetic variant is in the population">
-                  <span className="sst-label">Variant frequency</span>
-                  <span className="sst-value">{study.risk_allele_frequency}</span>
-                  <span className="sst-context">In population</span>
-                </div>
-              )}
-              <div className="study-stat-tile">
-                <span className="sst-label">Confidence</span>
-                <span className="sst-value">
-                  <span className={`quality-pill ${study.confidenceBand}`}>
-                    {study.confidenceBand === "high" ? "High" : study.confidenceBand === "medium" ? "Medium" : "Lower"}
-                  </span>
-                </span>
-                <span className="sst-context">
-                  {study.confidenceBand === "high" ? "Well-replicated" : study.confidenceBand === "medium" ? "Some caveats" : "Interpret carefully"}
-                </span>
-              </div>
             </div>
+          )}
 
-            {/* Genetic variants */}
-            {study.snps && (
-              <div className="study-variants-row">
-                <span className="study-variants-label">Variants tested</span>
-                <VariantChips snps={study.snps} riskAllele={study.strongest_snp_risk_allele} />
-              </div>
-            )}
+          {study.qualityFlags.length > 0 && (
+            <div className="study-quality-flags">
+              {study.qualityFlags.map((flag, index) => (
+                <div key={index} className={`quality-flag quality-flag-${flag.severity}`}>
+                  {flag.message}
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
 
-            {/* Sample breakdown */}
-            {(study.initial_sample_size || study.replication_sample_size) && (
-              <div className="study-sample-detail">
-                {study.initial_sample_size && (
-                  <p className="study-sample-row">
-                    <span className="study-sample-key">Initial sample</span>
-                    <span>{study.initial_sample_size}</span>
-                  </p>
-                )}
-                {study.replication_sample_size && (
-                  <p className="study-sample-row">
-                    <span className="study-sample-key">Replication</span>
-                    <span>{study.replication_sample_size}</span>
-                  </p>
-                )}
-              </div>
-            )}
-
-            {/* Quality flags */}
-            {study.qualityFlags.length > 0 && (
-              <div className="study-quality-flags">
-                {study.qualityFlags.map((flag, index) => (
-                  <div key={index} className={`quality-flag quality-flag-${flag.severity}`}>
-                    {flag.message}
-                  </div>
-                ))}
-              </div>
-            )}
-          </section>
-
-          {/* Bottom nav */}
-          <div style={{ marginBottom: "2rem" }}>
-            {navButtons}
-          </div>
-        </main>
-        <Footer />
-      </div>
-    </>
+        {/* Bottom nav */}
+        <div style={{ marginBottom: "2rem" }}>
+          <StudyNavButtons />
+        </div>
+      </main>
+      <Footer />
+    </div>
   );
 }

--- a/app/subscribe/page.tsx
+++ b/app/subscribe/page.tsx
@@ -54,11 +54,37 @@ function SubscribeContent() {
           <div className="subscribe-copy">
             <span className="premium-eyebrow">Premium</span>
             <h1>Subscribe to Monadic DNA Premium</h1>
-            <p>$4.99/month</p>
+            <p>$4.99/month. Cancel any time.</p>
           </div>
 
           <div className="subscribe-auth">
             <AuthButton />
+          </div>
+        </section>
+
+        <section className="subscribe-features">
+          <div className="subscribe-features-col">
+            <h3>Included with Premium</h3>
+            <ul>
+              <li>
+                <strong>Research in DNA Chat</strong>
+                Searches your results from 10 angles before synthesizing an answer. More thorough than a standard chat response.
+              </li>
+              <li>
+                <strong>All premium reports in Analyze</strong>
+                Healthspan, Top Traits, and Comprehensive Overview reports. <a href="/overview-report" style={{ color: 'var(--accent-blue)' }}>See what each report covers.</a>
+              </li>
+            </ul>
+          </div>
+          <div className="subscribe-features-col">
+            <h3>Always free</h3>
+            <ul className="free-list">
+              <li>Health Insights Report</li>
+              <li>Send in DNA Chat</li>
+              <li>Browse and search all studies</li>
+              <li>Explore your results</li>
+              <li>Upload your own DNA file</li>
+            </ul>
           </div>
         </section>
 
@@ -72,22 +98,21 @@ function SubscribeContent() {
           <section className="subscribe-status-card">
             <h2>Premium access is active</h2>
             <p>
-              Your subscription is ready for DNA Chat and Overview Report.
+              Research in DNA Chat and all premium reports are unlocked.
               {subscriptionData?.expiresAt
                 ? ` Your current billing period renews ${new Date(subscriptionData.expiresAt).toLocaleDateString()}.`
                 : ""}
             </p>
             <div className="subscribe-actions">
               <button onClick={() => router.push("/dna-chat")}>Open DNA Chat</button>
-              <button onClick={() => router.push("/overview-report")}>Open Overview Report</button>
+              <button onClick={() => router.push("/overview-report")}>Open Analyze</button>
             </div>
           </section>
         ) : !isAuthenticated ? (
           <section className="subscribe-status-card">
             <h2>Sign in to subscribe</h2>
             <p>
-              Sign in with your wallet first so your subscription can be tied
-              to your Monadic DNA account.
+              Sign in to continue. We do not store your genetic data, tie your DNA to your identity, or share your information with third parties.
             </p>
             <button className="primary-action" onClick={openAuthModal}>
               Sign In
@@ -165,6 +190,71 @@ function SubscribeContent() {
           min-width: 170px;
           display: flex;
           justify-content: flex-end;
+        }
+
+        .subscribe-features {
+          display: grid;
+          grid-template-columns: 1fr 1fr;
+          gap: 2rem;
+          margin-bottom: 2.5rem;
+          padding: 2rem;
+          border: 1px solid var(--border-color);
+          border-radius: 16px;
+          background: var(--surface-bg);
+        }
+
+        .subscribe-features-col h3 {
+          margin: 0 0 1rem;
+          font-size: 0.78rem;
+          font-weight: 800;
+          text-transform: uppercase;
+          letter-spacing: 0.04em;
+          color: var(--text-secondary);
+        }
+
+        .subscribe-features-col ul {
+          list-style: none;
+          margin: 0;
+          padding: 0;
+          display: flex;
+          flex-direction: column;
+          gap: 1rem;
+        }
+
+        .subscribe-features-col li {
+          font-size: 0.95rem;
+          color: var(--text-primary);
+          line-height: 1.5;
+          padding-left: 1.4rem;
+          position: relative;
+        }
+
+        .subscribe-features-col li::before {
+          content: '✓';
+          position: absolute;
+          left: 0;
+          color: #2563eb;
+          font-weight: 700;
+        }
+
+        .subscribe-features-col li strong {
+          display: block;
+          font-weight: 700;
+        }
+
+        .free-list li {
+          color: var(--text-secondary);
+        }
+
+        .free-list li::before {
+          color: var(--text-secondary);
+        }
+
+        @media (max-width: 720px) {
+          .subscribe-features {
+            grid-template-columns: 1fr;
+            gap: 1.5rem;
+          }
         }
 
         .subscribe-notice {

--- a/app/subscribe/page.tsx
+++ b/app/subscribe/page.tsx
@@ -53,7 +53,7 @@ function SubscribeContent() {
         <section className="subscribe-hero">
           <div className="subscribe-copy">
             <span className="premium-eyebrow">Premium</span>
-            <h1>Subscribe to Monadic DNA Premium</h1>
+            <h1>Subscribe to Monadic DNA Explorer Premium</h1>
             <p>$4.99/month. Cancel any time.</p>
           </div>
 

--- a/lib/study-service.ts
+++ b/lib/study-service.ts
@@ -1,0 +1,138 @@
+import { executeQuery } from "@/lib/db";
+import {
+  computeQualityFlags,
+  formatNumber,
+  formatPValue,
+  parseLogPValue,
+  parsePValue,
+  parseSampleSize,
+} from "@/lib/parsing";
+
+type ConfidenceBand = "high" | "medium" | "low";
+
+export type StudyData = {
+  id: number;
+  study_accession: string | null;
+  study: string | null;
+  disease_trait: string | null;
+  mapped_trait: string | null;
+  mapped_trait_uri: string | null;
+  mapped_gene: string | null;
+  first_author: string | null;
+  date: string | null;
+  journal: string | null;
+  pubmedid: string | null;
+  link: string | null;
+  initial_sample_size: string | null;
+  replication_sample_size: string | null;
+  p_value: string | null;
+  pvalue_mlog: string | null;
+  or_or_beta: string | null;
+  ci_text: string | null;
+  risk_allele_frequency: string | null;
+  strongest_snp_risk_allele: string | null;
+  snps: string | null;
+  sampleSize: number | null;
+  sampleSizeLabel: string;
+  pValueNumeric: number | null;
+  pValueLabel: string;
+  logPValue: number | null;
+  qualityFlags: Array<{ message: string; severity: string }>;
+  isLowQuality: boolean;
+  confidenceBand: ConfidenceBand;
+  publicationDate: number | null;
+  isAnalyzable: boolean;
+  nonAnalyzableReason?: string;
+};
+
+type RawRow = {
+  id: number;
+  study_accession: string | null;
+  study: string | null;
+  disease_trait: string | null;
+  mapped_trait: string | null;
+  mapped_trait_uri: string | null;
+  mapped_gene: string | null;
+  first_author: string | null;
+  date: string | null;
+  journal: string | null;
+  pubmedid: string | null;
+  link: string | null;
+  initial_sample_size: string | null;
+  replication_sample_size: string | null;
+  p_value: string | null;
+  pvalue_mlog: string | null;
+  or_or_beta: string | null;
+  ci_text: string | null;
+  risk_allele_frequency: string | null;
+  strongest_snp_risk_allele: string | null;
+  snps: string | null;
+};
+
+function determineConfidenceBand(
+  sampleSize: number | null,
+  pValue: number | null,
+  logPValue: number | null,
+  qualityFlags: Array<{ severity: string }>,
+): ConfidenceBand {
+  const hasMajorFlags = qualityFlags.some(f => f.severity === "major");
+  if (hasMajorFlags) return "low";
+  const meetsHigh =
+    sampleSize !== null && sampleSize >= 5000 &&
+    logPValue !== null && logPValue >= 9 &&
+    (pValue === null || pValue <= 5e-9);
+  if (meetsHigh) return "high";
+  const meetsMedium =
+    ((sampleSize ?? 0) >= 2000 || (logPValue ?? 0) >= 7) &&
+    (pValue === null || pValue <= 1e-6);
+  if (meetsMedium) return "medium";
+  return "low";
+}
+
+function parsePublicationDate(value: string | null): number | null {
+  if (!value) return null;
+  const ts = Date.parse(value.trim());
+  return Number.isNaN(ts) ? null : ts;
+}
+
+export async function fetchStudyById(studyId: number): Promise<StudyData | null> {
+  const rows = await executeQuery<RawRow>(
+    `SELECT id, study_accession, study, disease_trait, mapped_trait,
+            mapped_trait_uri, mapped_gene, first_author, date, journal,
+            pubmedid, link, initial_sample_size, replication_sample_size,
+            p_value, pvalue_mlog, or_or_beta, ci_text, risk_allele_frequency,
+            strongest_snp_risk_allele, snps
+     FROM gwas_catalog WHERE id = $1 LIMIT 1`,
+    [studyId],
+  );
+
+  if (rows.length === 0) return null;
+  const row = rows[0];
+
+  const sampleSize = parseSampleSize(row.initial_sample_size) ?? parseSampleSize(row.replication_sample_size);
+  const pValueNumeric = parsePValue(row.p_value);
+  const logPValue = parseLogPValue(row.pvalue_mlog) ?? (pValueNumeric ? -Math.log10(pValueNumeric) : null);
+  const qualityFlags = computeQualityFlags(sampleSize, pValueNumeric, logPValue);
+  const isLowQuality = qualityFlags.some(f => f.severity === "major");
+  const confidenceBand = determineConfidenceBand(sampleSize, pValueNumeric, logPValue, qualityFlags);
+  const publicationDate = parsePublicationDate(row.date);
+  const isAnalyzable = !!(row.snps && row.or_or_beta && row.strongest_snp_risk_allele);
+  const nonAnalyzableReason = !isAnalyzable
+    ? (!row.snps ? "Missing SNP data" : !row.or_or_beta ? "Missing effect size (OR/beta)" : "Missing risk allele")
+    : undefined;
+
+  return {
+    ...row,
+    sampleSize,
+    sampleSizeLabel: formatNumber(sampleSize),
+    pValueNumeric,
+    pValueLabel: formatPValue(pValueNumeric),
+    logPValue,
+    qualityFlags,
+    isLowQuality,
+    confidenceBand,
+    publicationDate,
+    isAnalyzable,
+    nonAnalyzableReason,
+  };
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -16,6 +16,8 @@ const nextConfig = {
   // Mark server-only packages as external (prevents bundling for browser)
   // Nillion packages removed - need webpack bundling to apply libsodium alias
   serverExternalPackages: [
+    'pg',
+    'pg-native',
     'onnxruntime-node',
     'sharp',
     'alchemy-sdk',
@@ -85,6 +87,9 @@ const nextConfig = {
         util: false,
         assert: false,
         'pino-pretty': false,
+        dns: false,
+        net: false,
+        tls: false,
       };
     }
 

--- a/scripts/stripe-subscribers.mjs
+++ b/scripts/stripe-subscribers.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/**
+ * Fetches subscriber data from Stripe: active and cancelled subscriptions,
+ * tenure, and total spend per customer.
+ *
+ * Setup:
+ *   Add STRIPE_SECRET_KEY=sk_live_... to scripts/ga-performance.env
+ *   node scripts/stripe-subscribers.mjs
+ *
+ * Output: summary printed to stdout, full data written to /tmp/stripe-subscribers-<timestamp>.json
+ */
+
+import { readFileSync, writeFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function loadEnv(envPath) {
+  const env = {};
+  for (const raw of readFileSync(envPath, 'utf8').split('\n')) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    const eq = line.indexOf('=');
+    if (eq === -1) continue;
+    const key = line.slice(0, eq).trim();
+    let val = line.slice(eq + 1).trim();
+    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+      val = val.slice(1, -1);
+    }
+    env[key] = val;
+  }
+  return env;
+}
+
+async function stripeGet(path, secretKey, params = {}, expand = []) {
+  const url = new URL(`https://api.stripe.com/v1/${path}`);
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+  for (const e of expand) url.searchParams.append('expand[]', e);
+  const res = await fetch(url.toString(), {
+    headers: { Authorization: `Bearer ${secretKey}` },
+  });
+  if (!res.ok) throw new Error(`Stripe ${path} failed (${res.status}): ${await res.text()}`);
+  return res.json();
+}
+
+async function paginate(path, secretKey, params = {}, expand = []) {
+  const items = [];
+  let startingAfter = null;
+  while (true) {
+    const p = { limit: '100', ...params };
+    if (startingAfter) p.starting_after = startingAfter;
+    const page = await stripeGet(path, secretKey, p, expand);
+    items.push(...page.data);
+    if (!page.has_more) break;
+    startingAfter = page.data[page.data.length - 1].id;
+  }
+  return items;
+}
+
+function formatDate(ts) {
+  if (!ts) return 'n/a';
+  return new Date(ts * 1000).toISOString().slice(0, 10);
+}
+
+function tenureDays(createdTs, endedTs) {
+  const end = endedTs ? endedTs * 1000 : Date.now();
+  return Math.round((end - createdTs * 1000) / (1000 * 60 * 60 * 24));
+}
+
+async function main() {
+  const envPath = join(__dirname, 'ga-performance.env');
+  const env = loadEnv(envPath);
+
+  const secretKey = env.STRIPE_SECRET_KEY;
+  if (!secretKey || secretKey.startsWith('sk_test_placeholder')) {
+    throw new Error('Add STRIPE_SECRET_KEY=sk_live_... to scripts/ga-performance.env');
+  }
+
+  console.log('Fetching subscriptions...');
+  const [activeSubs, cancelledSubs] = await Promise.all([
+    paginate('subscriptions', secretKey, { status: 'active' }, ['data.customer']),
+    paginate('subscriptions', secretKey, { status: 'canceled' }, ['data.customer']),
+  ]);
+
+  console.log(`  Active: ${activeSubs.length}, Cancelled: ${cancelledSubs.length}`);
+  console.log('Fetching invoices...');
+
+  // Collect all customer IDs
+  const allSubs = [...activeSubs, ...cancelledSubs];
+  const customerIds = [...new Set(allSubs.map(s =>
+    typeof s.customer === 'string' ? s.customer : s.customer?.id
+  ).filter(Boolean))];
+
+  // Fetch paid invoices per customer
+  console.log(`  Fetching invoices for ${customerIds.length} customers...`);
+  const spendByCustomer = {};
+  for (const customerId of customerIds) {
+    const invoices = await paginate('invoices', secretKey, {
+      customer: customerId,
+      status: 'paid',
+    });
+    spendByCustomer[customerId] = invoices.reduce((sum, inv) => sum + inv.amount_paid, 0);
+  }
+
+  // Build subscriber records
+  const records = allSubs.map(sub => {
+    const customerId = typeof sub.customer === 'string' ? sub.customer : sub.customer?.id;
+    const customerEmail = typeof sub.customer === 'object' ? sub.customer?.email : null;
+    const tenure = tenureDays(sub.created, sub.ended_at);
+    const totalSpendCents = spendByCustomer[customerId] || 0;
+
+    return {
+      subscriptionId: sub.id,
+      customerId,
+      customerEmail,
+      status: sub.status,
+      created: formatDate(sub.created),
+      cancelledAt: formatDate(sub.canceled_at),
+      endedAt: formatDate(sub.ended_at),
+      tenureDays: tenure,
+      tenureMonths: (tenure / 30).toFixed(1),
+      totalSpendUsd: (totalSpendCents / 100).toFixed(2),
+    };
+  });
+
+  records.sort((a, b) => new Date(b.created) - new Date(a.created));
+
+  // Summary stats
+  const active = records.filter(r => r.status === 'active');
+  const cancelled = records.filter(r => r.status !== 'active');
+  const allSpend = records.map(r => parseFloat(r.totalSpendUsd));
+  const cancelledTenures = cancelled.map(r => r.tenureDays);
+
+  const avg = arr => arr.length ? (arr.reduce((a, b) => a + b, 0) / arr.length) : 0;
+
+  console.log('\n--- Summary ---');
+  console.log(`Active subscribers:    ${active.length}`);
+  console.log(`Cancelled subscribers: ${cancelled.length}`);
+  console.log(`Total revenue:         $${allSpend.reduce((a, b) => a + b, 0).toFixed(2)}`);
+  console.log(`Avg spend per customer: $${avg(allSpend).toFixed(2)}`);
+  if (cancelledTenures.length) {
+    console.log(`Avg tenure (cancelled): ${avg(cancelledTenures).toFixed(0)} days (${(avg(cancelledTenures) / 30).toFixed(1)} months)`);
+  }
+  if (active.length) {
+    const activeTenures = active.map(r => r.tenureDays);
+    console.log(`Avg tenure (active):    ${avg(activeTenures).toFixed(0)} days (${(avg(activeTenures) / 30).toFixed(1)} months)`);
+  }
+
+  console.log('\n--- Subscribers ---');
+  for (const r of records) {
+    const label = r.status === 'active' ? '[active]   ' : '[cancelled]';
+    console.log(`${label} ${r.created}  tenure: ${r.tenureMonths}mo  spend: $${r.totalSpendUsd}  ${r.customerEmail || r.customerId}`);
+  }
+
+  // Write JSON output
+  const ts = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+  const outPath = `/tmp/stripe-subscribers-${ts}.json`;
+  writeFileSync(outPath, JSON.stringify({ summary: { active: active.length, cancelled: cancelled.length }, records }, null, 2));
+  console.log(`\nFull data written to: ${outPath}`);
+}
+
+main().catch(err => {
+  console.error(`\nError: ${err.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
- Subscribe page now shows a feature comparison (Premium vs. free) before the auth gate, so unauthenticated users understand what they are paying for before being asked to sign in.
- Premium gates in DNA Chat and Analyze now redirect all non-subscribers to `/subscribe` instead of opening the auth modal. Previously, unauthenticated users never saw the subscribe page or its feature list.
- The Research button in DNA Chat is now enabled for non-subscribers. Clicking it redirects to `/subscribe`. Previously it was disabled and gave no indication of how to unlock it.
- Subscribe page copy updated: product name corrected to "Monadic DNA Explorer Premium", privacy reassurance added to the sign-in prompt, active subscriber card updated to reflect all unlocked features.
- Study detail pages are now server-rendered. Previously the page was a client component that fetched data via `useEffect`, so search crawlers saw an empty shell. Now the study title, trait, author, statistics, and SNP data are in the initial HTML. Personal result banner and inline analysis remain client-side.
- `pg` added to `serverExternalPackages` and Node.js built-ins (`dns`, `net`, `tls`) added to the client webpack fallback to prevent bundling errors from the new server component.