### PR TITLE
Rationalize Product Tours + Some Tweaks from Analytics

### DIFF
--- a/app/browse/page.tsx
+++ b/app/browse/page.tsx
@@ -339,7 +339,7 @@ function ExplorePage() {
   });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [sectionCollapsed, setSectionCollapsed] = useState(true);
+  const [sectionCollapsed, setSectionCollapsed] = useState(false);
   const [showTermsModal, setShowTermsModal] = useState(false);
   const [isRunningAll, setIsRunningAll] = useState(false);
   const [runAllProgress, setRunAllProgress] = useState({ current: 0, total: 0 });

--- a/app/browse/page.tsx
+++ b/app/browse/page.tsx
@@ -28,6 +28,11 @@ import {
   trackQueryRun,
   trackExploreTabViewed,
   trackSearchModeChanged,
+  trackBrowsePageViewed,
+  trackBrowseFiltersExpanded,
+  trackBrowseSearchChanged,
+  trackStudyOpened,
+  trackRunAllCtaClicked,
 } from "@/lib/analytics";
 
 // Note: Metadata must be exported from layout.tsx or a server component
@@ -310,6 +315,7 @@ function ExplorePage() {
   useEffect(() => {
     if (mounted) {
       trackExploreTabViewed();
+      trackBrowsePageViewed();
     }
   }, [mounted]);
 
@@ -408,6 +414,7 @@ function ExplorePage() {
       startTransition(() => {
         updateFilter("search", value);
       });
+      trackBrowseSearchChanged(value);
     }
   }, [filters.search, updateFilter]);
 
@@ -570,6 +577,15 @@ function ExplorePage() {
     userInitiatedSearchRef.current = false;
   };
 
+  const SEARCH_CHIPS = ['sleep', 'cholesterol', 'caffeine', "Alzheimer's", 'diabetes'] as const;
+
+  const handleChipClick = (term: string) => {
+    userInitiatedSearchRef.current = true;
+    startTransition(() => updateFilter("search", term));
+    setSectionCollapsed(false);
+    trackBrowseSearchChanged(term);
+  };
+
 
   const handleColumnSort = (sortKey: SortOption) => {
     const newDirection = filters.sort === sortKey
@@ -601,6 +617,7 @@ function ExplorePage() {
   };
 
   const handleRunAll = () => {
+    trackRunAllCtaClicked();
     if (!genotypeData || genotypeData.size === 0) {
       trackRunAllFailed("explore", "no_genotype_data");
       alert("No SNPs found in your genetic data");
@@ -775,7 +792,18 @@ function ExplorePage() {
                 <p>Filter genetic association studies by various criteria.</p>
               </>
             )}
-            {sectionCollapsed && <h3>Study Filters</h3>}
+            {sectionCollapsed && (
+              <>
+                <h3>Study Filters</h3>
+                <div className="search-chips">
+                  {SEARCH_CHIPS.map(term => (
+                    <button key={term} className="search-chip" type="button" onClick={() => handleChipClick(term)}>
+                      {term}
+                    </button>
+                  ))}
+                </div>
+              </>
+            )}
           </div>
           <div className="hero-controls">
             {!sectionCollapsed && (
@@ -789,7 +817,10 @@ function ExplorePage() {
             <button
               className="collapse-button"
               type="button"
-              onClick={() => setSectionCollapsed(!sectionCollapsed)}
+              onClick={() => {
+                if (sectionCollapsed) trackBrowseFiltersExpanded();
+                setSectionCollapsed(!sectionCollapsed);
+              }}
               title={sectionCollapsed ? "Expand" : "Collapse"}
             >
               {sectionCollapsed ? "↓" : "↑"}
@@ -1074,7 +1105,7 @@ function ExplorePage() {
                   <tr key={`${study.id}-${index}`} className={study.isLowQuality ? "low-quality" : undefined}>
                     <td data-label="Study">
                       <div className="study-title">
-                        <Link href={`/study/${study.id}`} style={{ textDecoration: "none", color: "inherit" }}>
+                        <Link href={`/study/${study.id}`} style={{ textDecoration: "none", color: "inherit" }} onClick={() => trackStudyOpened(study.id)}>
                           {study.study ?? "Untitled study"}
                         </Link>
                       </div>

--- a/app/browse/page.tsx
+++ b/app/browse/page.tsx
@@ -313,13 +313,6 @@ function ExplorePage() {
     }
   }, [mounted]);
 
-  // Auto-show guided tour on first visit
-  useEffect(() => {
-    if (mounted && !hasCompletedTour(exploreTour.id)) {
-      setTourOpen(true);
-    }
-  }, [mounted]);
-
   const [filters, setFilters] = useState<Filters>(defaultFilters);
 
   useEffect(() => {
@@ -786,9 +779,7 @@ function ExplorePage() {
           </div>
           <div className="hero-controls">
             {!sectionCollapsed && (
-              <button className="tour-trigger-link" type="button" onClick={() => setTourOpen(true)}>
-                Take the tour
-              </button>
+              <button className="tour-help-button" type="button" onClick={() => setTourOpen(true)} title="Show tour" aria-label="Show tour">?</button>
             )}
             {!sectionCollapsed && (
               <button className="reset-button" type="button" onClick={resetFilters}>

--- a/app/components/MenuBar.tsx
+++ b/app/components/MenuBar.tsx
@@ -551,9 +551,7 @@ export default function MenuBar() {
 
         </div>
         <div className="menu-explain-row">
-          <button className="menu-explain-link" onClick={() => setMenuTourOpen(true)}>
-            Explain these buttons
-          </button>
+          <button className="tour-help-button" type="button" onClick={() => setMenuTourOpen(true)} title="Show tour" aria-label="Show tour">?</button>
         </div>
       </div>
       </div>

--- a/app/components/PaymentModal.tsx
+++ b/app/components/PaymentModal.tsx
@@ -409,7 +409,7 @@ export default function PaymentModal({ isOpen = true, onClose, onSuccess, displa
 
         <div className="modal-header">
           <h2>Subscribe to Premium</h2>
-          <p>Get DNA Chat and Overview Report</p>
+          <p>Research in DNA Chat + all premium reports</p>
         </div>
 
         {step === 'choice' && (

--- a/app/components/StripeSubscriptionForm.tsx
+++ b/app/components/StripeSubscriptionForm.tsx
@@ -170,11 +170,11 @@ function SubscriptionForm({ clientSecret, walletAddress, couponCode, discount, i
         <div className="features-list">
           <div className="feature-item">
             <span className="feature-icon">✓</span>
-            <span>DNA Chat Assistant</span>
+            <span>Research in DNA Chat</span>
           </div>
           <div className="feature-item">
             <span className="feature-icon">✓</span>
-            <span>Overview Report</span>
+            <span>All premium reports (Healthspan, Top Traits, Overview)</span>
           </div>
         </div>
 

--- a/app/components/UserDataUpload.tsx
+++ b/app/components/UserDataUpload.tsx
@@ -50,10 +50,31 @@ export function GenotypeProvider({ children }: { children: React.ReactNode }) {
       }
 
       if (!validateFileFormat(file)) {
-        throw new Error('Unsupported file type. Please upload a .txt, .tsv, or .csv file exported from 23andMe, AncestryDNA, MyHeritage, FTDNA, LivingDNA, or a compatible provider.');
+        throw new Error('Unsupported file type. Please upload a .txt, .tsv, .csv, or .gz file exported from 23andMe, AncestryDNA, MyHeritage, FTDNA, LivingDNA, or a compatible provider.');
       }
 
-      const fileContent = await file.text();
+      let fileContent: string;
+      if (fileExtension === 'gz') {
+        const buffer = await file.arrayBuffer();
+        const ds = new DecompressionStream('gzip');
+        const writer = ds.writable.getWriter();
+        writer.write(buffer);
+        writer.close();
+        const chunks: Uint8Array[] = [];
+        const reader = ds.readable.getReader();
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          if (value) chunks.push(value);
+        }
+        const total = chunks.reduce((n, c) => n + c.length, 0);
+        const combined = new Uint8Array(total);
+        let offset = 0;
+        for (const chunk of chunks) { combined.set(chunk, offset); offset += chunk.length; }
+        fileContent = new TextDecoder().decode(combined);
+      } else {
+        fileContent = await file.text();
+      }
       const hash = calculateFileHash(fileContent);
 
       const parseResult = detectAndParseGenotypeFile(fileContent);
@@ -199,7 +220,7 @@ export default function UserDataUpload() {
       <input
         ref={fileInputRef}
         type="file"
-        accept=".txt,.tsv,.csv"
+        accept=".txt,.tsv,.csv,.gz"
         onChange={handleFileSelect}
         className="genotype-file-input"
         id="genotype-upload"
@@ -208,7 +229,7 @@ export default function UserDataUpload() {
       <label htmlFor="genotype-upload" className={`genotype-upload-label ${isLoading ? 'loading' : ''}`}>
         {isLoading ? 'Analyzing your genetic map...' : 'Choose File to Upload'}
       </label>
-      <p className="upload-format-hint">23andMe, AncestryDNA, MyHeritage, FTDNA, LivingDNA, and more</p>
+      <p className="upload-format-hint">23andMe, AncestryDNA, MyHeritage, FTDNA, LivingDNA, and more. Compressed .gz files supported.</p>
       {error && (
         <div className="genotype-error">
           {error}

--- a/app/components/tours/tourContent.ts
+++ b/app/components/tours/tourContent.ts
@@ -53,13 +53,6 @@ export const exploreTour: TourContent = {
       selector: '[data-tour="run-all-button"]',
       placement: "bottom",
     },
-    {
-      name: "your_result",
-      title: "Your personal result",
-      body: "After analyzing, the Your Result column shows how your genotype compares to each study. Click any row to see the details.",
-      selector: '[data-tour="your-result-header"]',
-      placement: "bottom",
-    },
   ],
 };
 
@@ -73,27 +66,6 @@ export const dnaChatTour: TourContent = {
       body: "DNA Chat is an anonymous and confidential LLM chat that uses your genetic results as context. Ask anything about your traits, sleep, diet, or risks.",
     },
     myDataStep,
-    {
-      name: "prompts",
-      title: "Try a suggested prompt",
-      body: "Not sure what to ask? Tap any of these suggestions to fill the chat box. They're a great starting point.",
-      selector: ".example-questions",
-      placement: "top",
-    },
-    {
-      name: "input",
-      title: "Or type your own",
-      body: "Type any question about your DNA here. The chat keeps your context across follow-up questions.",
-      selector: "textarea.chat-input",
-      placement: "top",
-    },
-    {
-      name: "send",
-      title: "Send your question",
-      body: "Click here to send. The first answer pulls in your most relevant results as context and follow-ups continue the conversation.",
-      selector: ".chat-send-button",
-      placement: "top",
-    },
     {
       name: "attach",
       title: "Upload lab reports and documents",
@@ -162,13 +134,6 @@ export const menuBarTour: TourContent = {
       placement: "bottom",
     },
     {
-      name: "results",
-      title: "Results",
-      body: "Save your analysis results to a file or load a previous session. Use this to pick up where you left off or share results between devices.",
-      selector: '[data-tour="results-button"]',
-      placement: "bottom",
-    },
-    {
       name: "run_all",
       title: "Run All",
       body: "Analyze your DNA against every matching study in the GWAS Catalog in one go. The results feed DNA Chat and the Overview Report.",
@@ -194,20 +159,6 @@ export const menuBarTour: TourContent = {
       title: "Cache",
       body: "The first Run All downloads ~54 MB of GWAS Catalog data and stores it locally. Here you can see how much is cached or clear it to re-download.",
       selector: '[data-tour="cache-button"]',
-      placement: "bottom",
-    },
-    {
-      name: "help",
-      title: "Help",
-      body: "Reopen the onboarding tour or find answers to common questions here.",
-      selector: '[data-tour="help-button"]',
-      placement: "bottom",
-    },
-    {
-      name: "theme",
-      title: "Light / Dark mode",
-      body: "Toggle between light and dark themes. Your preference is saved and applied on every visit.",
-      selector: '[data-tour="theme-button"]',
       placement: "bottom",
     },
   ],

--- a/app/dna-chat/page.tsx
+++ b/app/dna-chat/page.tsx
@@ -230,13 +230,15 @@ export default function DNAChatPage() {
           )}
 
           <div className="dna-chat-inline-wrapper">
-            <button
-              className="dna-chat-tour-button"
-              type="button"
-              onClick={() => setTourOpen(true)}
-            >
-              Show me how to use this
-            </button>
+            <div style={{ textAlign: "right", marginBottom: "0.4rem" }}>
+              <button
+                className="tour-help-button"
+                type="button"
+                onClick={() => setTourOpen(true)}
+                title="Show tour"
+                aria-label="Show tour"
+              >?</button>
+            </div>
             <LLMChatInline initialInput={initialChatInput} />
           </div>
         </section>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1237,6 +1237,30 @@ button {
   margin-bottom: 0;
 }
 
+.search-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: 0.5rem;
+}
+
+.search-chip {
+  padding: 0.2rem 0.65rem;
+  border-radius: 999px;
+  border: 1px solid var(--border-color);
+  background: var(--surface-bg);
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+}
+
+.search-chip:hover {
+  border-color: var(--accent-blue);
+  color: var(--accent-blue);
+  background: rgba(59, 130, 246, 0.06);
+}
+
 .panel-title {
   margin: 0;
   font-size: 1.1rem;

--- a/app/globals.css
+++ b/app/globals.css
@@ -11832,37 +11832,27 @@ details[open] .summary-arrow {
   padding: 0.1rem 1rem 0.35rem;
 }
 
-.menu-explain-link {
-  background: none;
-  border: none;
-  color: var(--text-muted, #888);
-  font-size: 0.72rem;
+.tour-help-button {
+  width: 1.6rem;
+  height: 1.6rem;
+  border-radius: 50%;
+  border: 1.5px solid var(--text-secondary);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  font-weight: 600;
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
   padding: 0;
-  text-decoration: underline;
-  text-underline-offset: 2px;
-  opacity: 0.65;
+  transition: border-color 0.15s, color 0.15s;
 }
 
-.menu-explain-link:hover {
-  opacity: 1;
-  color: var(--accent-blue);
-}
-
-.tour-trigger-link {
-  background: none;
-  border: none;
-  color: var(--accent-blue);
-  font-size: 0.85rem;
-  cursor: pointer;
-  padding: 0.25rem 0.5rem;
-  border-radius: 4px;
-  text-decoration: underline;
-  text-underline-offset: 3px;
-}
-
-.tour-trigger-link:hover {
-  background: rgba(59, 130, 246, 0.08);
+.tour-help-button:hover {
+  border-color: var(--text-primary);
+  color: var(--text-primary);
 }
 
 .mobile-compatibility-notice {
@@ -12048,26 +12038,6 @@ details[open] .summary-arrow {
   position: relative;
 }
 
-.dna-chat-tour-button {
-  position: absolute;
-  top: 0.5rem;
-  right: 0.6rem;
-  z-index: 10;
-  padding: 0.25rem 0.6rem;
-  border-radius: 4px;
-  border: 1px solid rgba(15, 23, 42, 0.18);
-  background: rgba(255, 255, 255, 0.9);
-  color: rgba(15, 23, 42, 0.55);
-  font-size: 0.72rem;
-  font-weight: 500;
-  cursor: pointer;
-}
-
-.dna-chat-tour-button:hover {
-  background: #ffffff;
-  color: rgba(15, 23, 42, 0.85);
-  border-color: rgba(15, 23, 42, 0.35);
-}
 
 /* Browse page tab toggle */
 .browse-tab-toggle {

--- a/app/landing-client.tsx
+++ b/app/landing-client.tsx
@@ -77,12 +77,12 @@ export default function LandingClient() {
   const [sampleTotalBytes, setSampleTotalBytes] = useState(0);
 
   const loadSampleData = async () => {
-    trackSampleDataStarted('home');
-
     if (savedResults.length > 0) {
       router.push("/explore");
       return;
     }
+
+    trackSampleDataStarted('home');
 
     try {
       setSampleStatus("downloading");

--- a/app/overview-report/page.tsx
+++ b/app/overview-report/page.tsx
@@ -14,7 +14,7 @@ import { OverviewReportIcon } from "../components/Icons";
 import { useAuth } from "../components/AuthProvider";
 import { useResults } from "../components/ResultsContext";
 import { hasValidPromoAccess } from "@/lib/promo-access";
-import GuidedTour, { hasCompletedTour } from "../components/GuidedTour";
+import GuidedTour from "../components/GuidedTour";
 import { overviewReportTour } from "../components/tours/tourContent";
 import { trackOverviewReportViewed } from "@/lib/analytics";
 
@@ -43,12 +43,6 @@ export default function OverviewReportPage() {
     trackOverviewReportViewed();
   }, []);
 
-
-  useEffect(() => {
-    if (!hasCompletedTour(overviewReportTour.id)) {
-      setTourOpen(true);
-    }
-  }, []);
 
   const hasPremiumAccess = hasActiveSubscription || hasPromoAccess;
   const hasResults = savedResults.length > 0;
@@ -92,9 +86,7 @@ export default function OverviewReportPage() {
           gateDescription="Subscribe for $4.99/month to access Healthspan, Top Traits, and Overview reports."
         />
         <div style={{ textAlign: "right", padding: "0 1rem" }}>
-          <button className="tour-trigger-link" onClick={() => setTourOpen(true)}>
-            Take the tour
-          </button>
+          <button className="tour-help-button" type="button" onClick={() => setTourOpen(true)} title="Show tour" aria-label="Show tour">?</button>
         </div>
         <PremiumPaywall>{null}</PremiumPaywall>
 

--- a/app/subscribe/page.tsx
+++ b/app/subscribe/page.tsx
@@ -53,7 +53,7 @@ function SubscribeContent() {
         <section className="subscribe-hero">
           <div className="subscribe-copy">
             <span className="premium-eyebrow">Premium</span>
-            <h1>Subscribe to Monadic DNA Explorer Premium</h1>
+            <h1>Unlock research and premium reports</h1>
             <p>$4.99/month. Cancel any time.</p>
           </div>
 
@@ -80,7 +80,7 @@ function SubscribeContent() {
             <h3>Always free</h3>
             <ul className="free-list">
               <li>Health Insights Report</li>
-              <li>Send in DNA Chat</li>
+              <li>Ask questions in DNA Chat</li>
               <li>Browse and search all studies</li>
               <li>Explore your results</li>
               <li>Upload your own DNA file</li>

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -678,6 +678,26 @@ export function trackSearchModeChanged(mode: 'similarity' | 'exact') {
   trackEvent('search_mode_changed', { mode });
 }
 
+export function trackBrowsePageViewed() {
+  trackEvent('browse_page_viewed');
+}
+
+export function trackBrowseFiltersExpanded() {
+  trackEvent('browse_filters_expanded');
+}
+
+export function trackBrowseSearchChanged(query: string) {
+  trackEvent('browse_search_changed', { query_length: query.length });
+}
+
+export function trackStudyOpened(studyId: number) {
+  trackEvent('study_opened', { study_id: String(studyId) });
+}
+
+export function trackRunAllCtaClicked() {
+  trackEvent('run_all_cta_clicked');
+}
+
 export function trackStudyAnalysisStarted() {
   trackEvent('study_analysis_started');
 }

--- a/lib/genotype-parser.ts
+++ b/lib/genotype-parser.ts
@@ -361,7 +361,7 @@ export function validateFileSize(file: File, maxSizeMB: number = 50): boolean {
 }
 
 export function validateFileFormat(file: File): boolean {
-  const validExtensions = ['.txt', '.tsv', '.csv'];
+  const validExtensions = ['.txt', '.tsv', '.csv', '.gz'];
   const fileName = file.name.toLowerCase();
   return validExtensions.some(ext => fileName.endsWith(ext));
 }

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
# Growth and UX improvements

Four areas of change driven by GA4 funnel analysis: subscription copy consistency, tour friction reduction, Browse discoverability, and file upload improvements.

---

## Subscription copy consistency

The premium bundle was described differently across three surfaces — the subscribe page, the payment modal, and the Stripe checkout form. Aligned all three to the same language:

- Subscribe page headline: "Unlock research and premium reports" (was "Subscribe to Monadic DNA Explorer Premium")
- Payment modal subtitle: "Research in DNA Chat + all premium reports"
- Stripe form features: "Research in DNA Chat" and "All premium reports (Healthspan, Top Traits, Overview)"
- Free tier item on subscribe page: "Ask questions in DNA Chat" (was "Send in DNA Chat", which was too similar to the premium "Research in DNA Chat")

**Files:** `app/subscribe/page.tsx`, `app/components/PaymentModal.tsx`, `app/components/StripeSubscriptionForm.tsx`

---

## Tour rationalization

Tours were auto-opening on first visit to Explore and Overview Report, resulting in a high dismissal rate. Tours are now manual-only, triggered by a `?` icon button on each page.

- Removed auto-open `useEffect` from `/browse` and `/overview-report`
- Replaced all text-link tour triggers ("Take the tour", "Show me how to use this", "Explain these buttons") with a consistent circular `?` button using a new `.tour-help-button` CSS class
- Trimmed redundant steps from three tours:
  - **Explore** (5 → 4 steps): removed `your_result` — the column doesn't exist until after analysis
  - **DNA Chat** (6 → 4 steps): removed `prompts`, `input`, `send` — self-evident chat UI
  - **Menu Bar** (9 → 6 steps): removed `results`, `help`, `theme` — self-explanatory buttons
  - **Overview Report**: unchanged

**Files:** `app/components/tours/tourContent.ts`, `app/browse/page.tsx`, `app/overview-report/page.tsx`, `app/dna-chat/page.tsx`, `app/components/MenuBar.tsx`, `app/globals.css`

---

## Browse page discoverability

The search input was hidden inside the collapsed filter panel, meaning most users saw no obvious way to search. Added search chips visible when the panel is collapsed, and added missing analytics coverage.

### Search chips

Five topic chips (sleep, cholesterol, caffeine, Alzheimer's, diabetes) appear in the filter panel header when collapsed. Clicking a chip sets the search query and expands the panel.

### Analytics

Added five new GA4 events with no existing coverage:

| Event | When |
|---|---|
| `browse_page_viewed` | Page mount |
| `browse_filters_expanded` | User clicks expand when panel is collapsed |
| `browse_search_changed` | Debounced search input change or chip click (includes `query_length`) |
| `study_opened` | User clicks a study title link (includes `study_id`) |
| `run_all_cta_clicked` | User clicks Run All, before any confirmation dialog |

**Files:** `app/browse/page.tsx`, `lib/analytics.ts`, `app/globals.css`

---

## File upload improvements

### `.gz` decompression support

Users were uploading gzip-compressed DNA files (a common download format from several providers) and hitting a format validation error. The app now accepts `.gz` files and decompresses them in the browser using the native `DecompressionStream` API before parsing.

- `validateFileFormat` now accepts `.gz`
- `uploadGenotype` detects `.gz` by extension and decompresses via `DecompressionStream('gzip')` before passing content to the parser
- File input `accept` attribute updated to include `.gz`
- Format hint and error messages updated to mention `.gz`
- No new dependencies

### Analytics tracking fix

`trackSampleDataStarted` was firing before the early-exit check for existing saved results in `landing-client.tsx`. Users who already had results and clicked the sample data button would fire `started` without a corresponding `loaded`, inflating the apparent drop-off rate. The event now fires only when a load is actually initiated.

**Files:** `app/components/UserDataUpload.tsx`, `lib/genotype-parser.ts`, `app/landing-client.tsx`

---

## Test coverage

All 26 parser format checks pass after the `.gz` change:
- 23andMe (whitespace-delimited, no-call handling)
- AncestryDNA (tab-delimited, allele merge, chromosome 26)
- Monadic/MyHeritage (CSV, quoted fields)
- FTDNA famfinder (comment-prefixed column header)
- LivingDNA (split allele columns)
- Space-delimited header correctly rejected by Monadic parser
- `.gz` accepted, `.pdf`/`.vcf`/extensionless rejected
