### PR TITLE
Seven Day Free Trial + Subscribe Funnel Fixes

### DIFF
--- a/app/api/stripe/cancel-subscription/route.ts
+++ b/app/api/stripe/cancel-subscription/route.ts
@@ -34,27 +34,32 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Find all active subscriptions for these customers
+    // Find all active and trialing subscriptions for these customers
     const cancelledSubscriptions: string[] = [];
-    
-    for (const customer of customers.data) {
-      const subscriptions = await stripe.subscriptions.list({
-        customer: customer.id,
-        status: 'active',
-        limit: 100,
-      });
 
-      // Cancel all active subscriptions (cancel at period end)
-      for (const subscription of subscriptions.data) {
+    for (const customer of customers.data) {
+      const [active, trialing] = await Promise.all([
+        stripe.subscriptions.list({ customer: customer.id, status: 'active', limit: 100 }),
+        stripe.subscriptions.list({ customer: customer.id, status: 'trialing', limit: 100 }),
+      ]);
+
+      // Cancel active subscriptions at period end (user keeps access until billing date)
+      for (const subscription of active.data) {
         const updated = await stripe.subscriptions.update(subscription.id, {
           cancel_at_period_end: true,
         });
         cancelledSubscriptions.push(subscription.id);
-        console.log(`[Stripe] Cancelled subscription: ${subscription.id} for wallet ${walletAddress}`, {
+        console.log(`[Stripe] Scheduled cancellation: ${subscription.id} for wallet ${walletAddress}`, {
           cancel_at_period_end: updated.cancel_at_period_end,
           current_period_end: new Date(updated.current_period_end * 1000).toISOString(),
-          status: updated.status,
         });
+      }
+
+      // Cancel trialing subscriptions immediately — no charge has occurred
+      for (const subscription of trialing.data) {
+        await stripe.subscriptions.cancel(subscription.id);
+        cancelledSubscriptions.push(subscription.id);
+        console.log(`[Stripe] Immediately cancelled trial subscription: ${subscription.id} for wallet ${walletAddress}`);
       }
     }
 
@@ -67,7 +72,7 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({
       success: true,
-      message: `${cancelledSubscriptions.length} subscription(s) will be cancelled at the end of the billing period`,
+      message: `${cancelledSubscriptions.length} subscription(s) cancelled`,
       cancelledSubscriptions,
     });
   } catch (error: any) {

--- a/app/api/stripe/create-subscription/route.ts
+++ b/app/api/stripe/create-subscription/route.ts
@@ -101,6 +101,7 @@ export async function POST(request: NextRequest) {
           price: process.env.STRIPE_PRICE_ID,
         },
       ],
+      trial_period_days: 7,
       payment_behavior: 'default_incomplete',
       payment_settings: {
         save_default_payment_method: 'on_subscription',

--- a/app/components/AuthProvider.tsx
+++ b/app/components/AuthProvider.tsx
@@ -56,7 +56,7 @@ function AuthStateSync({
   useEffect(() => {
     console.log('[AuthStateSync] Dynamic state:', {
       hasUser: !!dynamicUser,
-      userAddress: dynamicUser?.verifiedCredentials?.[0]?.address
+      userAddress: dynamicUser?.verifiedCredentials?.find((c: any) => c.address)?.address
     });
 
     // If we have a user with a wallet, treat them as authenticated
@@ -160,7 +160,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const refreshSubscription = async (skipRetries = false) => {
-    const walletAddress = user?.verifiedCredentials?.[0]?.address;
+    const walletAddress = user?.verifiedCredentials?.find((c: any) => c.address)?.address;
     if (walletAddress) {
       // Clear any cached subscription data first
       localStorage.removeItem(`subscription_${walletAddress.toLowerCase()}`);
@@ -205,7 +205,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     // If we already have a user (from previous session), check subscription
     if (user) {
-      const walletAddress = user?.verifiedCredentials?.[0]?.address;
+      const walletAddress = user?.verifiedCredentials?.find((c: any) => c.address)?.address;
       if (walletAddress) {
         console.log('[AuthProvider] Checking subscription for existing user:', walletAddress);
         checkSubscription(walletAddress);
@@ -214,7 +214,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [isDynamicEnabled, isDynamicInitialized, user, checkSubscription]);
 
   const handleAuthStateChange = useCallback((isAuth: boolean, dynamicUser: any) => {
-    console.log('[AuthProvider] Auth state changed:', { isAuth, hasUser: !!dynamicUser, userAddress: dynamicUser?.verifiedCredentials?.[0]?.address });
+    console.log('[AuthProvider] Auth state changed:', { isAuth, hasUser: !!dynamicUser, userAddress: dynamicUser?.verifiedCredentials?.find((c: any) => c.address)?.address });
 
     const wasAuthenticated = isAuthenticated;
     setIsAuthenticated(isAuth);
@@ -227,7 +227,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setCheckingSubscription(false);
     } else if (dynamicUser && isDynamicInitialized) {
       // User logged in
-      const walletAddress = dynamicUser?.verifiedCredentials?.[0]?.address;
+      const walletAddress = dynamicUser?.verifiedCredentials?.find((c: any) => c.address)?.address;
       if (walletAddress) {
         console.log('[AuthProvider] User logged in, checking subscription:', walletAddress);
 

--- a/app/components/OverviewReportModal.tsx
+++ b/app/components/OverviewReportModal.tsx
@@ -563,8 +563,7 @@ export default function OverviewReportModal({ isOpen, onClose }: OverviewReportM
                 Overview Report requires an active premium subscription.
               </p>
               <p style={{ fontSize: '0.875rem', color: 'var(--text-secondary)' }}>
-                Subscribe for $4.99/month to unlock comprehensive LLM-powered analysis
-                of all your genetic results.
+                Try free for 7 days, then $4.99/month to unlock comprehensive analysis of all your genetic results.
               </p>
             </div>
           ) : progress.phase === 'idle' ? (

--- a/app/components/PaymentModal.tsx
+++ b/app/components/PaymentModal.tsx
@@ -431,7 +431,7 @@ export default function PaymentModal({ isOpen = true, onClose, onSuccess, displa
                 <div className="choice-icon">💳</div>
                 <div className="choice-details">
                   <div className="choice-title">Pay with Card</div>
-                  <div className="choice-description">$4.99/month subscription (Stripe)</div>
+                  <div className="choice-description">7 days free, then $4.99/month (Stripe)</div>
                 </div>
               </button>
 

--- a/app/components/PremiumFeatureHeader.tsx
+++ b/app/components/PremiumFeatureHeader.tsx
@@ -10,7 +10,7 @@ type PremiumFeatureHeaderProps = {
   featureName: string;
   description: string;
   gateTitle?: string;       // overrides default "featureName is a premium tab" / "Premium subscription required"
-  gateDescription?: string; // overrides default "Subscribe for $4.99/month to access featureName."
+  gateDescription?: string; // overrides default "Try free for 7 days, then $4.99/month to access featureName."
 };
 
 export default function PremiumFeatureHeader({
@@ -78,10 +78,10 @@ export default function PremiumFeatureHeader({
           <div className="subscription-prompt-inline">
             <div className="subscription-message">
               <strong>{gateTitle ?? 'Premium subscription required'}</strong>
-              <span>{gateDescription ?? `Subscribe for $4.99/month to access ${featureName}.`}</span>
+              <span>{gateDescription ?? `Try free for 7 days, then $4.99/month to access ${featureName}.`}</span>
             </div>
             <Link href="/subscribe" className="subscribe-button">
-              Subscribe
+              Try free
             </Link>
           </div>
         ) : (
@@ -155,7 +155,7 @@ export default function PremiumFeatureHeader({
                             return;
                           }
                           try {
-                            const walletAddress = user?.verifiedCredentials?.[0]?.address;
+                            const walletAddress = user?.verifiedCredentials?.find((c: any) => c.address)?.address;
                             if (!walletAddress) {
                               alert('Could not find wallet address');
                               return;

--- a/app/components/StripeSubscriptionForm.tsx
+++ b/app/components/StripeSubscriptionForm.tsx
@@ -160,11 +160,12 @@ function SubscriptionForm({ clientSecret, walletAddress, couponCode, discount, i
       {/* Pricing Summary */}
       <div className="pricing-card">
         <div className="pricing-header">
-          <h4>Premium Subscription</h4>
+          <h4>7-Day Free Trial</h4>
           <div className="price-display">
-            <span className="current-price">$4.99</span>
-            <span className="billing-period">/month</span>
+            <span className="current-price">$0</span>
+            <span className="billing-period"> today</span>
           </div>
+          <div className="trial-note">then $4.99/month, cancel any time</div>
         </div>
 
         <div className="features-list">
@@ -266,14 +267,14 @@ function SubscriptionForm({ clientSecret, walletAddress, couponCode, discount, i
               Processing...
             </>
           ) : (
-            'Subscribe Now'
+            'Start Free Trial'
           )}
         </button>
       </div>
 
       <div className="secure-notice">
         <span className="lock-icon">🔒</span>
-        <span>Secured by Stripe • Cancel anytime</span>
+        <span>Secured by Stripe • No charge for 7 days • Cancel anytime</span>
       </div>
 
       <style jsx>{`
@@ -324,6 +325,12 @@ function SubscriptionForm({ clientSecret, walletAddress, couponCode, discount, i
         .billing-period {
           font-size: 0.85rem;
           opacity: 0.9;
+        }
+
+        .trial-note {
+          font-size: 0.75rem;
+          opacity: 0.8;
+          margin-top: 0.15rem;
         }
 
         .features-list {

--- a/app/dna-chat/page.tsx
+++ b/app/dna-chat/page.tsx
@@ -180,7 +180,7 @@ export default function DNAChatPage() {
           featureName="DNA Chat Research"
           description="Send and chat are free. The Research feature requires a subscription."
           gateTitle="Research requires a subscription"
-          gateDescription="Subscribe for $4.99/month to unlock the Research feature in DNA Chat."
+          gateDescription="Try free for 7 days, then $4.99/month to unlock the Research feature in DNA Chat."
         />
         <section className="premium-section premium-feature-section dna-chat-section">
           {(sampleLoad.status === "downloading" || sampleLoad.status === "loading") && (

--- a/app/overview-report/page.tsx
+++ b/app/overview-report/page.tsx
@@ -83,7 +83,7 @@ export default function OverviewReportPage() {
           featureName="Analyze"
           description="Health Insights is free. Healthspan, Top Traits, and Overview reports require a subscription."
           gateTitle="Some reports require a subscription"
-          gateDescription="Subscribe for $4.99/month to access Healthspan, Top Traits, and Overview reports."
+          gateDescription="Try free for 7 days, then $4.99/month to access Healthspan, Top Traits, and Overview reports."
         />
         <div style={{ textAlign: "right", padding: "0 1rem" }}>
           <button className="tour-help-button" type="button" onClick={() => setTourOpen(true)} title="Show tour" aria-label="Show tour">?</button>

--- a/app/subscribe/layout.tsx
+++ b/app/subscribe/layout.tsx
@@ -2,14 +2,14 @@ import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "Subscribe - Monadic DNA Explorer",
-  description: "Get premium access to AI-powered DNA analysis, DNA Chat, and Overview Reports for $4.99/month.",
+  description: "Try Monadic DNA Explorer Premium free for 7 days, then $4.99/month. Research in DNA Chat, all premium reports. Cancel any time.",
   keywords: ["DNA analysis subscription", "personal genomics premium", "genetic insights subscription"],
   alternates: {
     canonical: "https://explorer.monadicdna.com/subscribe",
   },
   openGraph: {
     title: "Subscribe - Monadic DNA Explorer",
-    description: "Get premium access to AI-powered DNA analysis, DNA Chat, and Overview Reports for $4.99/month.",
+    description: "Try Monadic DNA Explorer Premium free for 7 days, then $4.99/month. Research in DNA Chat, all premium reports. Cancel any time.",
     type: "website",
     url: "https://explorer.monadicdna.com/subscribe",
     siteName: "Monadic DNA Explorer",
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary_large_image",
     title: "Subscribe - Monadic DNA Explorer",
-    description: "Get premium access to AI-powered DNA analysis, DNA Chat, and Overview Reports for $4.99/month.",
+    description: "Try Monadic DNA Explorer Premium free for 7 days, then $4.99/month. Research in DNA Chat, all premium reports. Cancel any time.",
     creator: "@MonadicDNA",
   },
 };

--- a/app/subscribe/page.tsx
+++ b/app/subscribe/page.tsx
@@ -54,7 +54,7 @@ function SubscribeContent() {
           <div className="subscribe-copy">
             <span className="premium-eyebrow">Premium</span>
             <h1>Unlock research and premium reports</h1>
-            <p>$4.99/month. Cancel any time.</p>
+            <p>7 days free, then $4.99/month. Cancel any time.</p>
           </div>
 
           <div className="subscribe-auth">

--- a/app/subscribe/page.tsx
+++ b/app/subscribe/page.tsx
@@ -37,7 +37,7 @@ function SubscribeContent() {
   };
 
   const paymentCancelled = searchParams.get("payment") === "cancelled";
-  const walletAddress = user?.verifiedCredentials?.[0]?.address;
+  const walletAddress = user?.verifiedCredentials?.find((c: any) => c.address)?.address;
   const subscribeState = hasActiveSubscription ? "subscribed" : isAuthenticated ? "signed_in" : "signed_out";
 
   useEffect(() => {

--- a/lib/subscription-manager.ts
+++ b/lib/subscription-manager.ts
@@ -44,20 +44,19 @@ export async function checkStripeSubscription(walletAddress: string): Promise<Su
       };
     }
 
-    // Collect all active subscriptions from all customers
+    // Collect all active and trialing subscriptions from all customers
     const allSubscriptions: Stripe.Subscription[] = [];
 
     for (const customer of customers.data) {
-      const subscriptions = await stripe.subscriptions.list({
-        customer: customer.id,
-        status: 'active',
-        limit: 100,
-      });
+      const [active, trialing] = await Promise.all([
+        stripe.subscriptions.list({ customer: customer.id, status: 'active', limit: 100 }),
+        stripe.subscriptions.list({ customer: customer.id, status: 'trialing', limit: 100 }),
+      ]);
 
-      allSubscriptions.push(...subscriptions.data);
+      allSubscriptions.push(...active.data, ...trialing.data);
     }
 
-    console.log(`[Stripe Manager] Found ${allSubscriptions.length} active subscriptions`);
+    console.log(`[Stripe Manager] Found ${allSubscriptions.length} active/trialing subscriptions`);
 
     if (allSubscriptions.length === 0) {
       console.log('[Stripe Manager] No active subscriptions found');
@@ -71,12 +70,15 @@ export async function checkStripeSubscription(walletAddress: string): Promise<Su
       };
     }
 
-    // Find the subscription with the latest current_period_end
+    // Find the subscription with the latest expiry (use trial_end for trialing subs)
+    const subExpiry = (sub: Stripe.Subscription) =>
+      sub.status === 'trialing' && sub.trial_end ? sub.trial_end : sub.current_period_end;
+
     const latestSubscription = allSubscriptions.reduce((latest, sub) => {
-      return sub.current_period_end > latest.current_period_end ? sub : latest;
+      return subExpiry(sub) > subExpiry(latest) ? sub : latest;
     });
 
-    const expiresAt = new Date(latestSubscription.current_period_end * 1000);
+    const expiresAt = new Date(subExpiry(latestSubscription) * 1000);
     const now = Date.now();
     const isActive = now < expiresAt.getTime();
     const daysRemaining = isActive

--- a/lib/subscription-manager.ts
+++ b/lib/subscription-manager.ts
@@ -53,7 +53,18 @@ export async function checkStripeSubscription(walletAddress: string): Promise<Su
         stripe.subscriptions.list({ customer: customer.id, status: 'trialing', limit: 100 }),
       ]);
 
-      allSubscriptions.push(...active.data, ...trialing.data);
+      allSubscriptions.push(...active.data);
+
+      // Only count trialing subscriptions that have a confirmed payment method attached.
+      // Without a payment method the user abandoned the form before submitting card details,
+      // so we should not grant access.
+      for (const sub of trialing.data) {
+        if (sub.default_payment_method) {
+          allSubscriptions.push(sub);
+        } else {
+          console.log(`[Stripe Manager] Skipping trialing subscription ${sub.id} — no payment method attached`);
+        }
+      }
     }
 
     console.log(`[Stripe Manager] Found ${allSubscriptions.length} active/trialing subscriptions`);

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/scripts/analyze-ga-performance.mjs
+++ b/scripts/analyze-ga-performance.mjs
@@ -142,6 +142,7 @@ const APP_EVENTS = [
   'premium_section_viewed',
   'premium_tab_viewed',
   'subscribe_page_viewed',
+  'payment_method_selected',
   'checkout_started',
   'checkout_submitted',
   'checkout_failed',
@@ -178,6 +179,61 @@ async function fetchEventCounts(propertyId, accessToken, startDate, endDate) {
     orderBys: [{ metric: { metricName: 'eventCount' }, desc: true }],
     limit: 100,
   });
+}
+
+async function fetchSubscribeFunnel(propertyId, accessToken, startDate, endDate) {
+  // Detailed funnel: subscribe_page_viewed broken down by customEvent:subscribe_state (if registered)
+  // plus payment_method_selected broken down by method
+  const [funnelReport, methodReport] = await Promise.all([
+    ga4Post(propertyId, accessToken, {
+      dateRanges: [{ startDate, endDate }],
+      dimensions: [{ name: 'eventName' }],
+      metrics: [{ name: 'eventCount' }],
+      dimensionFilter: {
+        filter: {
+          fieldName: 'eventName',
+          inListFilter: { values: ['subscribe_page_viewed', 'payment_method_selected', 'checkout_started', 'checkout_submitted', 'checkout_failed'] },
+        },
+      },
+      orderBys: [{ metric: { metricName: 'eventCount' }, desc: true }],
+      limit: 20,
+    }),
+    ga4Post(propertyId, accessToken, {
+      dateRanges: [{ startDate, endDate }],
+      dimensions: [{ name: 'eventName' }, { name: 'customEvent:method' }],
+      metrics: [{ name: 'eventCount' }],
+      dimensionFilter: {
+        filter: {
+          fieldName: 'eventName',
+          inListFilter: { values: ['payment_method_selected', 'checkout_started', 'checkout_failed'] },
+        },
+      },
+      orderBys: [{ metric: { metricName: 'eventCount' }, desc: true }],
+      limit: 20,
+    }).catch(() => ({ rows: [] })), // method dimension may not be registered
+  ]);
+  return { funnelReport, methodReport };
+}
+
+function formatSubscribeFunnel({ funnelReport, methodReport }) {
+  const lines = [];
+  if (funnelReport.rows?.length) {
+    lines.push('Step counts:');
+    funnelReport.rows.forEach(r => {
+      lines.push(`  ${r.dimensionValues[0].value.padEnd(35)} ${r.metricValues[0].value}`);
+    });
+  } else {
+    lines.push('(no subscribe funnel data)');
+  }
+  if (methodReport.rows?.length) {
+    lines.push('By method:');
+    methodReport.rows.forEach(r => {
+      const event = r.dimensionValues[0].value.padEnd(30);
+      const method = (r.dimensionValues[1].value || '?').padEnd(12);
+      lines.push(`  ${event} method=${method} count=${r.metricValues[0].value}`);
+    });
+  }
+  return lines.join('\n');
 }
 
 async function fetchSessionMetrics(propertyId, accessToken, startDate, endDate) {
@@ -238,7 +294,7 @@ async function queryOllama(baseUrl, model, prompt) {
 // Analysis prompt
 // ---------------------------------------------------------------------------
 
-function buildPrompt(periodLabel, sessionBlock, eventBlock) {
+function buildPrompt(periodLabel, sessionBlock, eventBlock, subscribeFunnelBlock) {
   return `You are analyzing performance data for "Monadic DNA Explorer" (codenamed GWASifier), a Next.js web app where users upload their personal DNA files (23andMe, AncestryDNA) and match them against GWAS (Genome-Wide Association Studies) research using AI analysis. Paid features cost $4.99/month.
 
 Core user journey:
@@ -248,13 +304,21 @@ Core user journey:
   4. Upload DNA: genotype_file_upload_started -> genotype_file_loaded (failure: genotype_file_upload_failed)
   5. Analyze matches: match_revealed, run_all_started -> run_all_completed
   6. AI features (premium): ai_analysis_run, llm_question_asked, overview_report_generated
-  7. Subscribe: subscribe_page_viewed -> checkout_started -> subscribed_credit_card / subscribed_stablecoin
+  7. Subscribe: subscribe_page_viewed -> payment_method_selected -> checkout_started -> subscribed_credit_card / subscribed_stablecoin
+
+Subscribe funnel notes:
+  - subscribe_page_viewed has a "state" dimension: signed_out (must sign in first), signed_in (wallet ready, can pay), subscribed (already subscribed)
+  - payment_method_selected fires when the user clicks "Pay with Card" or "Pay with Stablecoin" in the payment modal
+  - checkout_started fires when the Stripe form actually loads (card) or when stablecoin payment is submitted
+  - If subscribe_page_viewed(signed_out) >> subscribe_page_viewed(signed_in), most visitors are not signing in
+  - If payment_method_selected = 0, no one is clicking a payment button
 
 Key conversion funnels to evaluate:
   - Onboarding: onboarding_started -> onboarding_completed
   - DNA upload success: genotype_file_loaded / genotype_file_upload_started
   - AI engagement: ai_consent_given / match_revealed
   - Premium conversion: subscribed_* / subscribe_page_viewed
+  - Subscribe funnel: subscribe_page_viewed(signed_in) -> payment_method_selected -> checkout_started -> subscribed_*
 
 SESSION METRICS (${periodLabel}):
 ${sessionBlock}
@@ -262,11 +326,14 @@ ${sessionBlock}
 EVENT COUNTS (${periodLabel}):
 ${eventBlock}
 
+SUBSCRIBE FUNNEL BY AUTH STATE (${periodLabel}):
+${subscribeFunnelBlock}
+
 Analyze the above data and provide:
 1. Traffic summary (users, sessions, engagement quality)
 2. Onboarding funnel with completion rate
 3. Core feature usage (DNA upload, study exploration, AI analysis)
-4. Premium and subscription funnel (if any activity)
+4. Premium and subscription funnel — identify exactly where drop-off occurs (not signed in, not clicking pay, not completing checkout)
 5. What is working well, and what looks like it needs attention
 6. Any anomalies or patterns worth flagging
 
@@ -306,21 +373,25 @@ async function main() {
   const accessToken = await getAccessToken(clientEmail, privateKey);
 
   console.log(`Querying GA4 property ${propertyId} for ${periodLabel}...`);
-  const [eventReport, sessionReport] = await Promise.all([
+  const [eventReport, sessionReport, subscribeFunnelReport] = await Promise.all([
     fetchEventCounts(propertyId, accessToken, startDate, endDate),
     fetchSessionMetrics(propertyId, accessToken, startDate, endDate),
+    fetchSubscribeFunnel(propertyId, accessToken, startDate, endDate),
   ]);
 
   const sessionBlock = formatSessionMetrics(sessionReport);
   const eventBlock = formatEventTable(eventReport);
+  const subscribeFunnelBlock = formatSubscribeFunnel(subscribeFunnelReport);
 
   console.log('\n--- Session Metrics ---');
   console.log(sessionBlock);
   console.log('\n--- Event Counts ---');
   console.log(eventBlock);
+  console.log('\n--- Subscribe Funnel (by auth state) ---');
+  console.log(subscribeFunnelBlock);
 
   console.log(`\nSending to Ollama (${ollamaModel})...`);
-  const analysis = await queryOllama(ollamaBaseUrl, ollamaModel, buildPrompt(periodLabel, sessionBlock, eventBlock));
+  const analysis = await queryOllama(ollamaBaseUrl, ollamaModel, buildPrompt(periodLabel, sessionBlock, eventBlock, subscribeFunnelBlock));
 
   console.log('\n=== Performance Analysis ===');
   console.log(`Period: ${periodLabel}  |  Property: ${propertyId}  |  Model: ${ollamaModel}\n`);

--- a/scripts/analyze-ga-performance.mjs
+++ b/scripts/analyze-ga-performance.mjs
@@ -182,8 +182,7 @@ async function fetchEventCounts(propertyId, accessToken, startDate, endDate) {
 }
 
 async function fetchSubscribeFunnel(propertyId, accessToken, startDate, endDate) {
-  // Detailed funnel: subscribe_page_viewed broken down by customEvent:subscribe_state (if registered)
-  // plus payment_method_selected broken down by method
+  // Detailed funnel counts plus payment_method_selected broken down by method.
   const [funnelReport, methodReport] = await Promise.all([
     ga4Post(propertyId, accessToken, {
       dateRanges: [{ startDate, endDate }],
@@ -307,18 +306,16 @@ Core user journey:
   7. Subscribe: subscribe_page_viewed -> payment_method_selected -> checkout_started -> subscribed_credit_card / subscribed_stablecoin
 
 Subscribe funnel notes:
-  - subscribe_page_viewed has a "state" dimension: signed_out (must sign in first), signed_in (wallet ready, can pay), subscribed (already subscribed)
   - payment_method_selected fires when the user clicks "Pay with Card" or "Pay with Stablecoin" in the payment modal
   - checkout_started fires when the Stripe form actually loads (card) or when stablecoin payment is submitted
-  - If subscribe_page_viewed(signed_out) >> subscribe_page_viewed(signed_in), most visitors are not signing in
-  - If payment_method_selected = 0, no one is clicking a payment button
+  - If payment_method_selected = 0, no one is clicking a payment button after reaching the subscribe page
 
 Key conversion funnels to evaluate:
   - Onboarding: onboarding_started -> onboarding_completed
   - DNA upload success: genotype_file_loaded / genotype_file_upload_started
   - AI engagement: ai_consent_given / match_revealed
   - Premium conversion: subscribed_* / subscribe_page_viewed
-  - Subscribe funnel: subscribe_page_viewed(signed_in) -> payment_method_selected -> checkout_started -> subscribed_*
+  - Subscribe funnel: subscribe_page_viewed -> payment_method_selected -> checkout_started -> subscribed_*
 
 SESSION METRICS (${periodLabel}):
 ${sessionBlock}
@@ -326,14 +323,14 @@ ${sessionBlock}
 EVENT COUNTS (${periodLabel}):
 ${eventBlock}
 
-SUBSCRIBE FUNNEL BY AUTH STATE (${periodLabel}):
+SUBSCRIBE FUNNEL (${periodLabel}):
 ${subscribeFunnelBlock}
 
 Analyze the above data and provide:
 1. Traffic summary (users, sessions, engagement quality)
 2. Onboarding funnel with completion rate
 3. Core feature usage (DNA upload, study exploration, AI analysis)
-4. Premium and subscription funnel — identify exactly where drop-off occurs (not signed in, not clicking pay, not completing checkout)
+4. Premium and subscription funnel — identify where drop-off occurs from subscribe page view to payment selection to checkout completion
 5. What is working well, and what looks like it needs attention
 6. Any anomalies or patterns worth flagging
 
@@ -387,7 +384,7 @@ async function main() {
   console.log(sessionBlock);
   console.log('\n--- Event Counts ---');
   console.log(eventBlock);
-  console.log('\n--- Subscribe Funnel (by auth state) ---');
+  console.log('\n--- Subscribe Funnel ---');
   console.log(subscribeFunnelBlock);
 
   console.log(`\nSending to Ollama (${ollamaModel})...`);


### PR DESCRIPTION
**Free trial (Stripe card only)**
- Stripe subscriptions now include a 7-day trial period. Card details are collected upfront via SetupIntent; no charge until day 8.
- Trial access is gated on `default_payment_method` being set — abandoning the form before submitting card details grants no access.
- Trialing subscriptions are now included in cancellation (cancelled immediately, since no charge has occurred). Previously the cancel endpoint only queried `active` status, so trial users could not cancel before billing started.
- `subscription-manager.ts` uses `trial_end` as the expiry date for trialing subscriptions.

**Auth credential lookup fix**
- `verifiedCredentials?.[0]?.address` replaced with `verifiedCredentials?.find((c) => c.address)?.address` throughout `AuthProvider`, `subscribe/page`, and `PremiumFeatureHeader`. Users who sign in via email/social (where the wallet credential is not at index 0) were hitting the "Connect a wallet" gate on the subscribe page even though Dynamic had created an embedded wallet for them.

**Subscribe copy**
- All paywall surfaces updated to surface the free trial: gate banners, payment modal, Stripe form, subscribe page, and layout metadata.

**Analytics**
- `payment_method_selected` added to GA event tracking (was firing in code but not queried).
- New `fetchSubscribeFunnel` query in the analysis script tracks `subscribe_page_viewed → payment_method_selected → checkout_started` as a dedicated funnel section.
- Removed misleading "by auth state" label from the subscribe funnel output (the query does not include a state dimension).