### PR TITLE
Add Quick Previews for New Users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ yarn-error.log*
 /AGENTS.md
 /CLAUDE.md
 /scripts/ga-performance.env
+/.junie/

--- a/app/api/stripe/create-checkout/route.ts
+++ b/app/api/stripe/create-checkout/route.ts
@@ -5,6 +5,24 @@ const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || 'sk_test_placeholder'
   apiVersion: '2025-02-24.acacia',
 });
 
+async function getOrCreateCustomer(walletAddress: string) {
+  const normalizedWallet = walletAddress.toLowerCase();
+  const existingCustomers = await stripe.customers.search({
+    query: `metadata['walletAddress']:'${normalizedWallet}'`,
+    limit: 1,
+  });
+
+  if (existingCustomers.data[0]) {
+    return existingCustomers.data[0];
+  }
+
+  return stripe.customers.create({
+    metadata: {
+      walletAddress: normalizedWallet,
+    },
+  });
+}
+
 export async function POST(request: NextRequest) {
   try {
     const { walletAddress, couponCode } = await request.json();
@@ -40,8 +58,10 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Get the base URL for redirect
-    const origin = request.headers.get('origin') || process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+    const requestOrigin = request.headers.get('origin');
+    const forwardedProto = request.headers.get('x-forwarded-proto') || 'http';
+    const forwardedHost = request.headers.get('x-forwarded-host') || request.headers.get('host');
+    const origin = requestOrigin || process.env.NEXT_PUBLIC_APP_URL || (forwardedHost ? `${forwardedProto}://${forwardedHost}` : 'http://localhost:3001');
 
     // Validate promotion code if provided
     let discounts = undefined;
@@ -86,10 +106,13 @@ export async function POST(request: NextRequest) {
       }
     }
 
+    const customer = await getOrCreateCustomer(walletAddress);
+
     // Create Stripe Checkout Session for subscription
     const session = await stripe.checkout.sessions.create({
       payment_method_types: ['card'],
       mode: 'subscription', // Recurring subscription
+      customer: customer.id,
       line_items: [
         {
           price: process.env.STRIPE_PRICE_ID, // Reference existing price from Stripe Dashboard

--- a/app/components/LLMChatInline.tsx
+++ b/app/components/LLMChatInline.tsx
@@ -6,6 +6,7 @@ import { SavedResult } from "@/lib/results-manager";
 import { useResults } from "./ResultsContext";
 import { useCustomization } from "./CustomizationContext";
 import { useAuth } from "./AuthProvider";
+import { useGenotype } from "./UserDataUpload";
 import { hasValidPromoAccess } from "@/lib/promo-access";
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -57,6 +58,7 @@ export default function AIChatInline({ initialInput }: { initialInput?: string }
   const router = useRouter();
   const resultsContext = useResults();
   const { getTopResultsByRelevance } = resultsContext;
+  const { isUploaded } = useGenotype();
   const { customization, status: customizationStatus } = useCustomization();
   const { isAuthenticated, hasActiveSubscription, openAuthModal } = useAuth();
   const [hasPromoAccess, setHasPromoAccess] = useState(false);
@@ -352,7 +354,12 @@ export default function AIChatInline({ initialInput }: { initialInput?: string }
     setAttachmentError(null);
 
     // Track LLM question
-    trackLLMQuestionAsked({ isFollowUp: messages.length > 0 });
+    trackLLMQuestionAsked({
+      isFollowUp: messages.length > 0,
+      hasUploadedDna: isUploaded,
+      resultCount: resultsContext.savedResults.length,
+      source: 'chat',
+    });
 
     // Process attachments if any
     let processedAttachments: Attachment[] = [];
@@ -701,7 +708,12 @@ Write questions from the user's perspective — as if the user is asking you. No
     setError(null);
     setAttachmentError(null);
 
-    trackLLMQuestionAsked({ isFollowUp: messages.length > 0 });
+    trackLLMQuestionAsked({
+      isFollowUp: messages.length > 0,
+      hasUploadedDna: isUploaded,
+      resultCount: resultsContext.savedResults.length,
+      source: 'research',
+    });
 
     const userMessage: Message = { role: 'user', content: query, timestamp: new Date() };
     const assistantMessage: Message = { role: 'assistant', content: '', timestamp: new Date() };

--- a/app/components/MenuBar.tsx
+++ b/app/components/MenuBar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, type CSSProperties } from "react";
+import { useCallback, useState, useEffect, type CSSProperties } from "react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import UserDataUpload, { useGenotype } from "./UserDataUpload";
@@ -138,12 +138,15 @@ export default function MenuBar() {
   }, [theme]);
 
   useEffect(() => {
-    const handleOpenDNAUpload = () => {
+    const handleOpenDNAUpload = (event: Event) => {
       setShowMyDataDropdown(true);
+      const source = event instanceof CustomEvent && typeof event.detail?.source === "string"
+        ? event.detail.source
+        : "home_upload_raw_dna";
 
       // Wait for the dropdown and uploader to mount, then open the file picker.
       setTimeout(() => {
-        window.dispatchEvent(new CustomEvent('openDNAUploadPicker'));
+        window.dispatchEvent(new CustomEvent('openDNAUploadPicker', { detail: { source } }));
       }, 60);
     };
 
@@ -151,6 +154,14 @@ export default function MenuBar() {
 
     return () => {
       window.removeEventListener('openDNAUpload', handleOpenDNAUpload);
+    };
+  }, []);
+
+  useEffect(() => {
+    const handleOpenPersonalization = () => setShowCustomizationModal(true);
+    window.addEventListener("openPersonalization", handleOpenPersonalization);
+    return () => {
+      window.removeEventListener("openPersonalization", handleOpenPersonalization);
     };
   }, []);
 
@@ -171,7 +182,7 @@ export default function MenuBar() {
     }
   };
 
-  const handleRunAll = () => {
+  const handleRunAll = useCallback(() => {
     window.dispatchEvent(new Event("showMobileCompatibilityNotice"));
 
     if (isRunningAll) {
@@ -187,7 +198,7 @@ export default function MenuBar() {
     }
 
     setShowRunAllDisclaimer(true);
-  };
+  }, [genotypeData, isRunningAll]);
 
   const handleRunAllDisclaimerAccept = async () => {
     setShowRunAllDisclaimer(false);
@@ -317,6 +328,18 @@ export default function MenuBar() {
 
   const isDNAChatActive = pathname === "/dna-chat" || pathname === "/llm-chat";
   const isOverviewReportActive = pathname === "/overview-report";
+  const isPublicEntryPage = pathname === "/" || pathname === "/raw-dna-guide";
+  const hasUserWork = isUploaded || savedResults.length > 0;
+  const showAdvancedControls = !isPublicEntryPage || hasUserWork;
+  const showRunAllControl = !isPublicEntryPage || isUploaded || savedResults.length > 0;
+
+  useEffect(() => {
+    const handleStartRunAll = () => handleRunAll();
+    window.addEventListener("startRunAllAnalysis", handleStartRunAll);
+    return () => {
+      window.removeEventListener("startRunAllAnalysis", handleStartRunAll);
+    };
+  }, [handleRunAll]);
 
   return (
     <>
@@ -424,13 +447,15 @@ export default function MenuBar() {
           >
             Browse
           </Link>
-          <Link
-            href="/overview-report"
-            className={isOverviewReportActive ? "nav-link active" : "nav-link"}
-            style={getNavLinkStyle(isOverviewReportActive)}
-          >
-            Analyze
-          </Link>
+          {showAdvancedControls && (
+            <Link
+              href="/overview-report"
+              className={isOverviewReportActive ? "nav-link active" : "nav-link"}
+              style={getNavLinkStyle(isOverviewReportActive)}
+            >
+              Analyze
+            </Link>
+          )}
         </nav>
       </div>
 
@@ -452,75 +477,85 @@ export default function MenuBar() {
             )}
           </button>
 
-          <button
-            className="menu-icon-button"
-            onClick={() => setShowResultsDropdown(!showResultsDropdown)}
-            title="Load, export, and manage results"
-            data-tour="results-button"
-          >
-            <span className="icon">
-              <FolderIcon size={32} />
-            </span>
-            <span className="label">Results</span>
-            {savedResults.length > 0 && (
-              <span className="badge">{savedResults.length}</span>
-            )}
-          </button>
+          {showAdvancedControls && (
+            <button
+              className="menu-icon-button"
+              onClick={() => setShowResultsDropdown(!showResultsDropdown)}
+              title="Load, export, and manage results"
+              data-tour="results-button"
+            >
+              <span className="icon">
+                <FolderIcon size={32} />
+              </span>
+              <span className="label">Results</span>
+              {savedResults.length > 0 && (
+                <span className="badge">{savedResults.length}</span>
+              )}
+            </button>
+          )}
 
-          <button
-            className={isRunningAll ? "menu-icon-button running" : "menu-icon-button"}
-            onClick={handleRunAll}
-            title="Analyze your DNA against all matching GWAS traits"
-            data-tour="run-all-button"
-          >
-            <span className="icon">
-              <RunAllIcon size={32} />
-            </span>
-            <span className="label">Run All</span>
-            {isRunningAll && (
-              <span className="badge">Running</span>
-            )}
-          </button>
+          {showRunAllControl && (
+            <button
+              className={isRunningAll ? "menu-icon-button running" : "menu-icon-button"}
+              onClick={handleRunAll}
+              title="Analyze your DNA against all matching GWAS traits"
+              data-tour="run-all-button"
+            >
+              <span className="icon">
+                <RunAllIcon size={32} />
+              </span>
+              <span className="label">Run All</span>
+              {isRunningAll && (
+                <span className="badge">Running</span>
+              )}
+            </button>
+          )}
 
-          <button
-            className={`menu-icon-button ${customizationStatus}`}
-            onClick={() => setShowCustomizationModal(true)}
-            title={getCustomizationTooltip()}
-            data-tour="personalize-button"
-          >
-            <span className="icon">
-              <MicroscopeIcon size={32} />
-            </span>
-            <span className="label">Personalize</span>
-          </button>
+          {showAdvancedControls && (
+            <button
+              className={`menu-icon-button ${customizationStatus}`}
+              onClick={() => setShowCustomizationModal(true)}
+              title={getCustomizationTooltip()}
+              data-tour="personalize-button"
+            >
+              <span className="icon">
+                <MicroscopeIcon size={32} />
+              </span>
+              <span className="label">Personalize</span>
+            </button>
+          )}
 
-          <button
-            className="menu-icon-button"
-            onClick={() => setShowLLMConfigModal(true)}
-            title="Configure LLM provider and model"
-            data-tour="llm-config-button"
-          >
-            <span className="icon">
-              <SparklesIcon size={32} />
-            </span>
-            <span className="label">LLM</span>
-            <span className="badge">{llmProvider || 'OpenAI'}</span>
-          </button>
+          {showAdvancedControls && (
+            <button
+              className="menu-icon-button"
+              onClick={() => setShowLLMConfigModal(true)}
+              title="Configure LLM provider and model"
+              data-tour="llm-config-button"
+            >
+              <span className="icon">
+                <SparklesIcon size={32} />
+              </span>
+              <span className="label">LLM</span>
+              <span className="badge">{llmProvider || 'OpenAI'}</span>
+            </button>
+          )}
 
-          <button
-            className="menu-icon-button"
-            onClick={() => setShowCacheDropdown(!showCacheDropdown)}
-            title="View and manage cached GWAS data"
-            data-tour="cache-button"
-          >
-            <span className="icon">
-              <CacheIcon size={32} />
-            </span>
-            <span className="label">Cache</span>
-            {cacheInfo && (
-              <span className="badge">{cacheInfo.studies.toLocaleString()}</span>
-            )}
-          </button>
+          {showAdvancedControls && (
+            <button
+              className="menu-icon-button"
+              onClick={() => setShowCacheDropdown(!showCacheDropdown)}
+              title="View and manage cached GWAS data"
+              data-tour="cache-button"
+            >
+              <span className="icon">
+                <CacheIcon size={32} />
+              </span>
+              <span className="label">Cache</span>
+              {cacheInfo && (
+                <span className="badge">{cacheInfo.studies.toLocaleString()}</span>
+              )}
+            </button>
+          )}
 
           <button
             className="menu-icon-button"

--- a/app/components/ResultsContext.tsx
+++ b/app/components/ResultsContext.tsx
@@ -36,6 +36,17 @@ type ResultsContextType = {
 };
 
 const ResultsContext = createContext<ResultsContextType | null>(null);
+const RESULTS_SESSION_FLAG = "monadic_results_session_started";
+
+function markResultsSessionStarted() {
+  if (typeof window === "undefined") return;
+  sessionStorage.setItem(RESULTS_SESSION_FLAG, "true");
+}
+
+function clearResultsSessionFlag() {
+  if (typeof window === "undefined") return;
+  sessionStorage.removeItem(RESULTS_SESSION_FLAG);
+}
 
 export function ResultsProvider({ children }: { children: ReactNode }) {
   // SECURITY: Results stored in memory only (in SQL.js in-memory database), cleared on session end
@@ -63,11 +74,13 @@ export function ResultsProvider({ children }: { children: ReactNode }) {
 
   const addResult = async (result: SavedResult) => {
     await resultsDB.insertResult(result);
+    markResultsSessionStarted();
     await syncFromDatabase();
   };
 
   const addResultsBatch = async (results: SavedResult[]) => {
     await resultsDB.insertResultsBatch(results);
+    if (results.length > 0) markResultsSessionStarted();
     await syncFromDatabase();
   };
 
@@ -79,6 +92,7 @@ export function ResultsProvider({ children }: { children: ReactNode }) {
   const clearResults = async () => {
     await resultsDB.clear();
     setSavedResults([]);
+    clearResultsSessionFlag();
   };
 
   const saveToFile = async (genotypeSize?: number, genotypeHash?: string) => {
@@ -129,6 +143,7 @@ export function ResultsProvider({ children }: { children: ReactNode }) {
       // Load into SQL database
       await resultsDB.clear();
       await resultsDB.insertResultsBatch(session.results);
+      if (session.results.length > 0) markResultsSessionStarted();
       await syncFromDatabase();
 
       // SECURITY: No longer saving to localStorage

--- a/app/components/StripeSubscriptionForm.tsx
+++ b/app/components/StripeSubscriptionForm.tsx
@@ -12,6 +12,18 @@ import {
 
 const stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY!);
 
+interface InitializePaymentResponse {
+  success: boolean;
+  clientSecret?: string;
+  isSetupIntent?: boolean;
+  subscriptionId?: string;
+  customerId?: string;
+  discount?: DiscountInfo;
+  error?: string;
+}
+
+const paymentInitializationRequests = new Map<string, Promise<InitializePaymentResponse>>();
+
 interface DiscountInfo {
   originalAmount: string;
   discountAmount: string;
@@ -608,36 +620,51 @@ export default function StripeSubscriptionForm({ walletAddress, onSuccess, onCan
   const [subscriptionId, setSubscriptionId] = useState<string | null>(null);
   const [customerId, setCustomerId] = useState<string | null>(null);
 
-  const [hasInitialized, setHasInitialized] = React.useState(false);
   const checkoutStartedRef = React.useRef(false);
+  const activeRequestKeyRef = React.useRef<string | null>(null);
 
-  const initializePayment = (promoCode: string) => {
-    // Prevent double initialization
-    if (hasInitialized && !promoCode) {
+  const initializePayment = React.useCallback((promoCode: string) => {
+    const normalizedPromoCode = promoCode.trim();
+    const requestKey = `${walletAddress.toLowerCase()}:${normalizedPromoCode || 'none'}`;
+
+    if (activeRequestKeyRef.current === requestKey && (isInitializing || clientSecret)) {
       return;
     }
 
+    activeRequestKeyRef.current = requestKey;
     setIsInitializing(true);
     setError(null);
+    setClientSecret(null);
     if (!checkoutStartedRef.current) {
       checkoutStartedRef.current = true;
-      trackCheckoutStarted('card', { hasPromoCode: !!promoCode.trim(), amount: 4.99, currency: 'USD' });
+      trackCheckoutStarted('card', { hasPromoCode: !!normalizedPromoCode, amount: 4.99, currency: 'USD' });
     }
 
-    console.log('[StripeForm] Initializing subscription for wallet:', walletAddress, 'with promo:', promoCode || 'none');
+    console.log('[StripeForm] Initializing subscription for wallet:', walletAddress, 'with promo:', normalizedPromoCode || 'none');
 
-    // Create subscription
-    fetch('/api/stripe/create-subscription', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        walletAddress,
-        couponCode: promoCode.trim() || undefined
-      }),
-    })
-      .then((res) => res.json())
+    let request = paymentInitializationRequests.get(requestKey);
+    if (!request) {
+      request = fetch('/api/stripe/create-subscription', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          walletAddress,
+          couponCode: normalizedPromoCode || undefined
+        }),
+      })
+        .then((res) => res.json())
+        .finally(() => {
+          paymentInitializationRequests.delete(requestKey);
+        });
+      paymentInitializationRequests.set(requestKey, request);
+    }
+
+    request
       .then((data) => {
         console.log('[StripeForm] Subscription response:', data);
+        if (activeRequestKeyRef.current !== requestKey) {
+          return;
+        }
 
         if (data.success) {
           if (data.clientSecret) {
@@ -645,9 +672,8 @@ export default function StripeSubscriptionForm({ walletAddress, onSuccess, onCan
             setIsSetupIntent(data.isSetupIntent || false);
             setSubscriptionId(data.subscriptionId || null);
             setCustomerId(data.customerId || null);
-            setHasInitialized(true);
-            if (promoCode) {
-              setAppliedCoupon(promoCode);
+            if (normalizedPromoCode) {
+              setAppliedCoupon(normalizedPromoCode);
             }
             // Set discount info from API response
             if (data.discount) {
@@ -667,22 +693,26 @@ export default function StripeSubscriptionForm({ walletAddress, onSuccess, onCan
         }
       })
       .catch((err) => {
+        if (activeRequestKeyRef.current !== requestKey) {
+          return;
+        }
         setError('Network error. Please try again.');
         trackCheckoutFailed('card', err instanceof Error ? err.message : 'network_error');
         console.error('[StripeForm] Network error:', err);
       })
       .finally(() => {
-        setIsInitializing(false);
+        if (activeRequestKeyRef.current === requestKey) {
+          setIsInitializing(false);
+        }
       });
-  };
+  }, [clientSecret, isInitializing, walletAddress]);
 
   React.useEffect(() => {
     initializePayment('');
-  }, []);
+  }, [initializePayment]);
 
   const handleApplyPromo = (code: string) => {
     trackStripePromoCodeApplied();
-    setHasInitialized(false);
     initializePayment(code);
   };
 
@@ -801,7 +831,7 @@ export default function StripeSubscriptionForm({ walletAddress, onSuccess, onCan
 
   return (
     <div>
-      <Elements stripe={stripePromise} options={options}>
+      <Elements key={clientSecret} stripe={stripePromise} options={options}>
         <SubscriptionForm
           clientSecret={clientSecret}
           walletAddress={walletAddress}

--- a/app/components/StudyPersonalResultBanner.tsx
+++ b/app/components/StudyPersonalResultBanner.tsx
@@ -7,6 +7,7 @@ import { hasMatchingSNPs } from "@/lib/snp-utils";
 import { analyzeStudyClientSide, UserStudyResult, determineEffectTypeAndSize } from "@/lib/risk-calculator";
 import DisclaimerModal from "./DisclaimerModal";
 import { SavedResult } from "@/lib/results-manager";
+import { getEvidenceDetails, getEvidenceLabel } from "@/lib/evidence-labels";
 import { trackStudyResultReveal } from "@/lib/analytics";
 
 type Props = {
@@ -20,6 +21,10 @@ type Props = {
   ciText?: string | null;
   isAnalyzable?: boolean;
   nonAnalyzableReason?: string;
+  pValue?: string | null;
+  pValueMlog?: string | null;
+  initialSampleSize?: string | null;
+  replicationSampleSize?: string | null;
 };
 
 function formatRiskScore(score: number, level: string, effectType?: string): string {
@@ -93,9 +98,13 @@ export default function StudyPersonalResultBanner({
   ciText,
   isAnalyzable,
   nonAnalyzableReason,
+  pValue,
+  pValueMlog,
+  initialSampleSize,
+  replicationSampleSize,
 }: Props) {
   const { genotypeData, isUploaded } = useGenotype();
-  const { addResult, hasResult, getResult, resultsVersion } = useResults();
+  const { addResult, hasResult, getResult } = useResults();
   const [result, setResult] = useState<UserStudyResult | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [isRevealed, setIsRevealed] = useState(false);
@@ -104,7 +113,41 @@ export default function StudyPersonalResultBanner({
 
   const savedResult = useMemo(() => {
     return hasResult(studyId) ? getResult(studyId) : undefined;
-  }, [studyId, resultsVersion, hasResult, getResult]);
+  }, [studyId, hasResult, getResult]);
+
+  const evidenceResult = useMemo<SavedResult | null>(() => {
+    if (savedResult) return savedResult;
+    if (!result?.hasMatch) return null;
+
+    return {
+      studyId,
+      gwasId: result.gwasId,
+      traitName,
+      studyTitle,
+      userGenotype: result.userGenotype || "",
+      riskAllele: result.riskAllele || "",
+      effectSize: result.effectSize || "",
+      effectType: result.effectType,
+      riskScore: result.riskScore || 1,
+      riskLevel: result.riskLevel || "neutral",
+      matchedSnp: result.matchedSnp || "",
+      analysisDate: new Date().toISOString(),
+      pValue: pValue || undefined,
+      pValueMlog: pValueMlog || undefined,
+      sampleSize: initialSampleSize || undefined,
+      replicationSampleSize: replicationSampleSize || undefined,
+    };
+  }, [
+    initialSampleSize,
+    pValue,
+    pValueMlog,
+    replicationSampleSize,
+    result,
+    savedResult,
+    studyId,
+    studyTitle,
+    traitName,
+  ]);
 
   useLayoutEffect(() => {
     if (savedResult) {
@@ -157,6 +200,10 @@ export default function StudyPersonalResultBanner({
           riskLevel: analysisResult.riskLevel!,
           matchedSnp: analysisResult.matchedSnp!,
           analysisDate: new Date().toISOString(),
+          pValue: pValue || undefined,
+          pValueMlog: pValueMlog || undefined,
+          sampleSize: initialSampleSize || undefined,
+          replicationSampleSize: replicationSampleSize || undefined,
         };
         await addResult(toSave);
       }
@@ -203,6 +250,16 @@ export default function StudyPersonalResultBanner({
           </div>
         </div>
         <p className="srb-explanation">{generateTooltip(result)}</p>
+        {evidenceResult && (
+          <div className={`srb-evidence srb-evidence--${getEvidenceLabel(evidenceResult).toLowerCase().split(" ")[0]}`}>
+            <strong>{getEvidenceLabel(evidenceResult)}</strong>
+            <div className="srb-evidence-items">
+              {getEvidenceDetails(evidenceResult).map((detail) => (
+                <span key={detail}>{detail}</span>
+              ))}
+            </div>
+          </div>
+        )}
       </div>
     );
   }

--- a/app/components/StudyPersonalSection.tsx
+++ b/app/components/StudyPersonalSection.tsx
@@ -18,6 +18,10 @@ type Props = {
   pubmedId?: string | null;
   mappedGene?: string | null;
   reportedTrait?: string | null;
+  pValue?: string | null;
+  pValueMlog?: string | null;
+  initialSampleSize?: string | null;
+  replicationSampleSize?: string | null;
 };
 
 export default function StudyPersonalSection({
@@ -34,6 +38,10 @@ export default function StudyPersonalSection({
   pubmedId,
   mappedGene,
   reportedTrait,
+  pValue,
+  pValueMlog,
+  initialSampleSize,
+  replicationSampleSize,
 }: Props) {
   const { hasResult, getResult } = useResults();
   const result = getResult(studyId);
@@ -51,6 +59,10 @@ export default function StudyPersonalSection({
         ciText={ciText}
         isAnalyzable={isAnalyzable}
         nonAnalyzableReason={nonAnalyzableReason}
+        pValue={pValue}
+        pValueMlog={pValueMlog}
+        initialSampleSize={initialSampleSize}
+        replicationSampleSize={replicationSampleSize}
       />
       {hasResult(studyId) && result && (
         <StudyInlineAnalysis

--- a/app/components/UserDataUpload.tsx
+++ b/app/components/UserDataUpload.tsx
@@ -5,9 +5,13 @@ import { GenotypeData, detectAndParseGenotypeFile, validateFileSize, validateFil
 import { calculateFileHash } from "@/lib/file-hash";
 import {
   trackFileCleared,
+  trackGenotypeParseStarted,
+  trackGenotypeParseSucceeded,
   trackGenotypeFileLoaded,
   trackGenotypeFileUploadFailed,
   trackGenotypeFileUploadStarted,
+  trackProviderGuideClicked,
+  trackUploadPickerOpened,
 } from "@/lib/analytics";
 import {
   isDevModeEnabled,
@@ -24,6 +28,9 @@ type GenotypeContextType = {
   setOnDataLoadedCallback: (callback: (() => void) | null) => void;
   fileHash: string | null;
   originalFileName: string | null;
+  originalFileSize: number | null;
+  detectedFormat: string | null;
+  fileExtension: string | null;
 };
 
 const GenotypeContext = createContext<GenotypeContextType | null>(null);
@@ -35,6 +42,9 @@ export function GenotypeProvider({ children }: { children: React.ReactNode }) {
   const onDataLoadedRef = useRef<(() => void) | null>(null);
   const [fileHash, setFileHash] = useState<string | null>(null);
   const [originalFileName, setOriginalFileName] = useState<string | null>(null);
+  const [originalFileSize, setOriginalFileSize] = useState<number | null>(null);
+  const [detectedFormat, setDetectedFormat] = useState<string | null>(null);
+  const [storedFileExtension, setStoredFileExtension] = useState<string | null>(null);
 
   const uploadGenotype = async (file: File, source: string = 'unknown') => {
     const dotIdx = file.name.lastIndexOf('.');
@@ -77,6 +87,7 @@ export function GenotypeProvider({ children }: { children: React.ReactNode }) {
       }
       const hash = calculateFileHash(fileContent);
 
+      trackGenotypeParseStarted(source, fileExtension);
       const parseResult = detectAndParseGenotypeFile(fileContent);
 
       if (!parseResult.success) {
@@ -90,11 +101,15 @@ export function GenotypeProvider({ children }: { children: React.ReactNode }) {
         genotypeMap.set(variant.rsid, variant.genotype);
       });
 
+      trackGenotypeParseSucceeded(source, parseResult.detectedFormat, genotypeMap.size);
       trackGenotypeFileLoaded(file.size, genotypeMap.size, source, parseResult.detectedFormat, fileExtension);
 
       setGenotypeData(genotypeMap);
       setFileHash(hash);
       setOriginalFileName(file.name);
+      setOriginalFileSize(file.size);
+      setDetectedFormat(parseResult.detectedFormat || null);
+      setStoredFileExtension(fileExtension || null);
 
       if (onDataLoadedRef.current) {
         onDataLoadedRef.current();
@@ -116,6 +131,9 @@ export function GenotypeProvider({ children }: { children: React.ReactNode }) {
     setError(null);
     setFileHash(null);
     setOriginalFileName(null);
+    setOriginalFileSize(null);
+    setDetectedFormat(null);
+    setStoredFileExtension(null);
     trackFileCleared();
   };
 
@@ -135,6 +153,9 @@ export function GenotypeProvider({ children }: { children: React.ReactNode }) {
       setOnDataLoadedCallback,
       fileHash,
       originalFileName,
+      originalFileSize,
+      detectedFormat,
+      fileExtension: storedFileExtension,
     }}>
       {children}
     </GenotypeContext.Provider>
@@ -150,12 +171,26 @@ export function useGenotype() {
 }
 
 export default function UserDataUpload() {
-  const { uploadGenotype, clearGenotype, isUploaded, isLoading, error } = useGenotype();
+  const {
+    uploadGenotype,
+    clearGenotype,
+    isUploaded,
+    isLoading,
+    error,
+    genotypeData,
+    originalFileName,
+    originalFileSize,
+    detectedFormat,
+  } = useGenotype();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    const openFilePicker = () => {
+    const openFilePicker = (event: Event) => {
       if (!isLoading) {
+        const source = event instanceof CustomEvent && typeof event.detail?.source === 'string'
+          ? event.detail.source
+          : 'menu_upload';
+        trackUploadPickerOpened(source);
         fileInputRef.current?.click();
       }
     };
@@ -168,6 +203,12 @@ export default function UserDataUpload() {
       window.removeEventListener('triggerDNAUpload', openFilePicker);
     };
   }, [isLoading]);
+
+  const formatFileSize = (bytes: number | null) => {
+    if (!bytes) return null;
+    if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  };
 
   const handleFileSelect = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -184,7 +225,7 @@ export default function UserDataUpload() {
           }
           return;
         }
-      } catch (error) {
+      } catch {
         console.log('[Dev Mode] Failed to use File System Access API, falling back to regular upload');
       }
     }
@@ -199,11 +240,23 @@ export default function UserDataUpload() {
   };
 
   if (isUploaded) {
+    const fileSizeLabel = formatFileSize(originalFileSize);
     return (
       <div className="genotype-status">
-        <span className="genotype-indicator">
-          ✓ DNA loaded - ready to explore
-        </span>
+        <div className="genotype-status-main">
+          <span className="genotype-indicator">
+            DNA file loaded
+          </span>
+          <span className="genotype-status-detail">
+            {genotypeData?.size.toLocaleString()} variants parsed
+            {detectedFormat ? ` from ${detectedFormat}` : ""}
+            {fileSizeLabel ? `, ${fileSizeLabel}` : ""}
+          </span>
+          {originalFileName && (
+            <span className="genotype-status-file">{originalFileName}</span>
+          )}
+          <span className="genotype-status-privacy">The raw file stayed in this browser.</span>
+        </div>
         <button
           className="genotype-clear"
           onClick={clearGenotype}
@@ -230,6 +283,13 @@ export default function UserDataUpload() {
         {isLoading ? 'Analyzing your genetic map...' : 'Choose File to Upload'}
       </label>
       <p className="upload-format-hint">23andMe, AncestryDNA, MyHeritage, FTDNA, LivingDNA, and more. Compressed .gz files supported.</p>
+      <div className="provider-guide-row" aria-label="Raw DNA download guides">
+        <a href="https://monadicdna.com/guide/23andme" target="_blank" rel="noopener noreferrer" onClick={() => trackProviderGuideClicked("23andme", "upload")}>23andMe</a>
+        <a href="https://monadicdna.com/guide/ancestry" target="_blank" rel="noopener noreferrer" onClick={() => trackProviderGuideClicked("ancestry", "upload")}>AncestryDNA</a>
+        <a href="https://monadicdna.com/guide/myheritage" target="_blank" rel="noopener noreferrer" onClick={() => trackProviderGuideClicked("myheritage", "upload")}>MyHeritage</a>
+        <a href="https://monadicdna.com/guide/ftdna" target="_blank" rel="noopener noreferrer" onClick={() => trackProviderGuideClicked("ftdna", "upload")}>FTDNA</a>
+        <a href="https://monadicdna.com/guide/livingdna" target="_blank" rel="noopener noreferrer" onClick={() => trackProviderGuideClicked("livingdna", "upload")}>LivingDNA</a>
+      </div>
       {error && (
         <div className="genotype-error">
           {error}
@@ -248,7 +308,7 @@ export default function UserDataUpload() {
         >
           Download Sample Data
         </a>
-        <p className="sample-description">Try the app with an anonymized sample dataset if you don't have your own DNA file yet.</p>
+        <p className="sample-description">Try the app with an anonymized sample dataset if you do not have your own DNA file yet.</p>
       </div>
     </div>
   );

--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -8,7 +8,13 @@ import Footer from "../components/Footer";
 import { useResults } from "../components/ResultsContext";
 import { useGenotype } from "../components/UserDataUpload";
 import { useCustomization } from "../components/CustomizationContext";
-import { trackExplorePageViewed } from "@/lib/analytics";
+import { trackExploreFollowupClicked, trackExplorePageViewed } from "@/lib/analytics";
+import {
+  buildPreviewInsight,
+  formatPreviewEffect,
+  getPreviewCategory,
+  selectAhaPreviewResults,
+} from "@/lib/preview-insights";
 
 const STOP_WORDS = new Set([
   'and', 'or', 'the', 'of', 'with', 'in', 'to', 'a', 'an', 'for', 'by', 'at', 'on',
@@ -33,19 +39,37 @@ function scoreMatch(keywords: string[], traitName: string): number {
 
 export default function ExplorePage() {
   const router = useRouter();
-  const { savedResults } = useResults();
+  const { savedResults, loadFromFile } = useResults();
   const { isUploaded } = useGenotype();
   const { customization, status: customizationStatus } = useCustomization();
   const [navigating, setNavigating] = useState(false);
   const [shownIncreased, setShownIncreased] = useState(5);
+  const [privateSessionWasCleared, setPrivateSessionWasCleared] = useState(false);
+  const [loadResultsError, setLoadResultsError] = useState<string | null>(null);
 
   useEffect(() => { trackExplorePageViewed(); }, []);
   const [shownDecreased, setShownDecreased] = useState(5);
   const [healthCardPages, setHealthCardPages] = useState<Record<string, number>>({});
 
-  const INITIAL_SHOW = 5;
   const PAGE_SIZE = 5;
   const hasResults = savedResults.length > 0;
+  const isQuickPreview = isUploaded && savedResults.length > 0 && savedResults.length <= 24;
+
+  useEffect(() => {
+    if (hasResults) {
+      setPrivateSessionWasCleared(false);
+      return;
+    }
+
+    setPrivateSessionWasCleared(sessionStorage.getItem("monadic_results_session_started") === "true");
+  }, [hasResults]);
+
+  const chatQuestion = "I just ran a quick preview on my raw DNA file. Which of these results should I pay attention to first, and what caveats matter?";
+  const chatHref = `/dna-chat?q=${encodeURIComponent(chatQuestion)}`;
+  const previewInsight = useMemo(
+    () => (hasResults ? buildPreviewInsight(savedResults) : null),
+    [hasResults, savedResults]
+  );
 
   const stats = useMemo(() => {
     if (!hasResults) return null;
@@ -76,6 +100,12 @@ export default function ExplorePage() {
     return { increased, decreased, neutral, topIncreased, topDecreased, unique };
   }, [savedResults, hasResults]);
 
+  const previewStarterResults = useMemo(() => {
+    if (!hasResults) return [];
+
+    return selectAhaPreviewResults(savedResults, 4);
+  }, [hasResults, savedResults]);
+
   const healthMatches = useMemo(() => {
     if (!hasResults || !customization || !stats) return [];
     const conditions = [
@@ -105,6 +135,25 @@ export default function ExplorePage() {
     setNavigating(true);
     const result = savedResults[Math.floor(Math.random() * savedResults.length)];
     router.push(`/study/${result.studyId}`);
+  };
+
+  const handleRunFullAnalysis = () => {
+    trackExploreFollowupClicked("run_full_analysis");
+    window.dispatchEvent(new CustomEvent("startRunAllAnalysis"));
+  };
+
+  const handleOpenPersonalization = () => {
+    trackExploreFollowupClicked("personalize");
+    window.dispatchEvent(new CustomEvent("openPersonalization"));
+  };
+
+  const handleLoadSavedResults = async () => {
+    setLoadResultsError(null);
+    try {
+      await loadFromFile();
+    } catch (error) {
+      setLoadResultsError(error instanceof Error ? error.message : "Could not load the results file.");
+    }
   };
 
   return (
@@ -144,6 +193,90 @@ export default function ExplorePage() {
                 <span className="explore-stat-label">neutral</span>
               </div>
             </div>
+
+            {isQuickPreview && previewInsight && (
+              <section className="explore-next-steps" aria-label="Quick preview next steps">
+                <div className="explore-next-steps-copy">
+                  <span className="explore-next-steps-eyebrow">First readout</span>
+                  <h2>{previewInsight.headline}</h2>
+                  <p>
+                    The quick preview scanned a wider candidate set and kept {savedResults.length.toLocaleString()} readable matches. This starter set has {previewInsight.elevatedCount} elevated and {previewInsight.protectiveCount} reduced associations. Treat these as research leads, not diagnoses.
+                  </p>
+                </div>
+
+                <div className="explore-next-actions">
+                  <button className="explore-next-primary" onClick={handleRunFullAnalysis}>
+                    Run the full catalog
+                  </button>
+                  <Link
+                    className="explore-next-secondary"
+                    href={chatHref}
+                    onClick={() => trackExploreFollowupClicked("ask_dna_chat")}
+                  >
+                    Ask what matters first
+                  </Link>
+                  <button className="explore-next-secondary" onClick={handleOpenPersonalization}>
+                    Add health history
+                  </button>
+                  <Link
+                    className="explore-next-secondary"
+                    href="/browse"
+                    onClick={() => trackExploreFollowupClicked("browse")}
+                  >
+                    Browse all studies
+                  </Link>
+                </div>
+
+                <div className="explore-preview-guide">
+                  {previewInsight.standout && (
+                    <Link
+                      href={`/study/${previewInsight.standout.studyId}`}
+                      className="explore-preview-insight-card explore-preview-insight-card--link"
+                    >
+                      <strong>Standout match</strong>
+                      <span className="explore-preview-insight-title">{previewInsight.standout.traitName}</span>
+                      <small>{getPreviewCategory(previewInsight.standout).label}, {formatPreviewEffect(previewInsight.standout)}</small>
+                    </Link>
+                  )}
+                  <div className="explore-preview-insight-card">
+                    <strong>Main themes</strong>
+                    <div className="explore-theme-list" aria-label="Main quick preview themes">
+                      {previewInsight.themes.map((theme) => (
+                        <span key={theme.label}>{theme.label} <b>{theme.count}</b></span>
+                      ))}
+                    </div>
+                  </div>
+                  <Link
+                    href={chatHref}
+                    className="explore-preview-insight-card explore-preview-insight-card--link"
+                    onClick={() => trackExploreFollowupClicked("preview_best_question")}
+                  >
+                    <strong>Best next question</strong>
+                    <span>Which of these findings should I read first, and what caveats matter?</span>
+                  </Link>
+                </div>
+
+                {previewStarterResults.length > 0 && (
+                  <div className="explore-preview-results-panel">
+                    <h3>Start with these preview matches</h3>
+                    <div className="explore-preview-result-list">
+                      {previewStarterResults.map((result) => (
+                        <Link
+                          key={`${result.studyId}-${result.matchedSnp}-${result.traitName}`}
+                          href={`/study/${result.studyId}`}
+                          className={`explore-highlight-item explore-highlight-item--${result.riskLevel}`}
+                        >
+                          <span className="explore-highlight-trait" title={result.traitName}>{result.traitName}</span>
+                          <span className="explore-highlight-score">
+                            {formatPreviewEffect(result, true)}
+                          </span>
+                        </Link>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </section>
+            )}
 
             {/* Discovery card */}
             <div className="explore-discovery-card">
@@ -311,6 +444,27 @@ export default function ExplorePage() {
           </>
         ) : (
           <>
+            {privateSessionWasCleared && (
+              <section className="explore-session-recovery" aria-label="Private session recovery">
+                <div>
+                  <span className="explore-next-steps-eyebrow">Private session cleared</span>
+                  <h2>Your previous results were kept in memory and cleared by the page reload.</h2>
+                  <p>
+                    This protects your DNA data from being stored automatically. Reload a saved results file, or go back to the home page and run the quick preview again.
+                  </p>
+                  {loadResultsError && <p className="explore-session-recovery-error">{loadResultsError}</p>}
+                </div>
+                <div className="explore-session-recovery-actions">
+                  <button className="explore-next-primary" onClick={handleLoadSavedResults}>
+                    Load saved results
+                  </button>
+                  <Link className="explore-next-secondary" href="/">
+                    Upload again
+                  </Link>
+                </div>
+              </section>
+            )}
+
             {/* Empty state — how it works */}
             <div className="explore-how-it-works">
               <h2 className="explore-section-title">How it works</h2>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1888,6 +1888,23 @@ tbody tr:hover {
   opacity: 0.8;
 }
 
+.provider-guide-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.provider-guide-row a {
+  border: 1px solid rgba(59, 130, 246, 0.18);
+  border-radius: 999px;
+  padding: 0.25rem 0.55rem;
+  background: rgba(59, 130, 246, 0.06);
+  color: var(--accent-blue);
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-decoration: none;
+}
+
 .sample-data-section {
   display: flex;
   flex-direction: column;
@@ -1984,18 +2001,45 @@ tbody tr:hover {
 
 .genotype-status {
   display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 0.75rem;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.75rem;
   background: rgba(16, 185, 129, 0.05);
   border: 1px solid rgba(16, 185, 129, 0.1);
   border-radius: 6px;
 }
 
+.genotype-status-main {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
 .genotype-indicator {
   font-size: 0.85rem;
   color: var(--accent-green);
-  font-weight: 500;
+  font-weight: 800;
+}
+
+.genotype-status-detail,
+.genotype-status-file,
+.genotype-status-privacy {
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  line-height: 1.35;
+}
+
+.genotype-status-file {
+  overflow: hidden;
+  max-width: 18rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.genotype-status-privacy {
+  color: var(--accent-green);
 }
 
 .genotype-clear {
@@ -2456,6 +2500,236 @@ tbody tr:hover {
   height: 2rem;
   background: var(--border-color);
   flex-shrink: 0;
+}
+
+.explore-next-steps {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(280px, 0.75fr);
+  gap: 1.25rem;
+  margin-bottom: 1.5rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(37, 99, 235, 0.22);
+  border-left: 4px solid var(--accent-blue);
+  border-radius: 12px;
+  background:
+    linear-gradient(135deg, rgba(37, 99, 235, 0.08), rgba(16, 185, 129, 0.05)),
+    var(--surface-bg);
+  box-shadow: 0 10px 26px rgba(15, 23, 42, 0.06);
+}
+
+.explore-next-steps-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+  min-width: 0;
+}
+
+.explore-next-steps-eyebrow {
+  width: fit-content;
+  border: 1px solid rgba(37, 99, 235, 0.24);
+  border-radius: 999px;
+  padding: 0.25rem 0.6rem;
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--accent-blue);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.explore-next-steps h2 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 1.35rem;
+  line-height: 1.2;
+}
+
+.explore-next-steps p {
+  max-width: 68ch;
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  line-height: 1.65;
+}
+
+.explore-next-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  align-self: start;
+}
+
+.explore-next-primary,
+.explore-next-secondary {
+  display: inline-flex;
+  min-height: 2.55rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  padding: 0.65rem 0.9rem;
+  font-size: 0.88rem;
+  font-weight: 800;
+  text-decoration: none;
+  cursor: pointer;
+  transition: transform 0.15s, opacity 0.15s, border-color 0.15s, background 0.15s;
+}
+
+.explore-next-primary {
+  border: 1px solid transparent;
+  background: linear-gradient(135deg, #2563eb, #0f766e);
+  color: #ffffff;
+  box-shadow: 0 8px 20px rgba(37, 99, 235, 0.2);
+}
+
+.explore-next-secondary {
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(255, 255, 255, 0.66);
+  color: var(--text-primary);
+}
+
+.explore-next-primary:hover,
+.explore-next-secondary:hover {
+  transform: translateY(-1px);
+  opacity: 0.9;
+}
+
+.explore-preview-guide {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+  padding-top: 0.25rem;
+}
+
+.explore-preview-guide > * {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.8rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.48);
+  text-decoration: none;
+}
+
+.explore-preview-guide strong,
+.explore-preview-results-panel h3 {
+  color: var(--text-primary);
+  font-size: 0.82rem;
+}
+
+.explore-preview-guide span {
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  line-height: 1.45;
+}
+
+.explore-preview-insight-card--link {
+  transition: transform 0.15s, border-color 0.15s, background 0.15s;
+}
+
+.explore-preview-insight-card--link:hover {
+  transform: translateY(-1px);
+  border-color: rgba(37, 99, 235, 0.35);
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.explore-preview-insight-title {
+  color: var(--text-primary) !important;
+  font-weight: 800;
+}
+
+.explore-preview-insight-card small {
+  color: var(--text-muted);
+  font-size: 0.76rem;
+  line-height: 1.35;
+}
+
+.explore-theme-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 0.1rem;
+}
+
+.explore-theme-list span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  width: fit-content;
+  border: 1px solid rgba(37, 99, 235, 0.18);
+  border-radius: 999px;
+  padding: 0.2rem 0.5rem;
+  background: rgba(37, 99, 235, 0.06);
+  color: var(--text-primary);
+  font-weight: 650;
+}
+
+.explore-theme-list b {
+  color: var(--accent-blue);
+}
+
+.explore-preview-results-panel {
+  grid-column: 1 / -1;
+  display: grid;
+  gap: 0.7rem;
+  padding-top: 0.25rem;
+}
+
+.explore-preview-results-panel h3 {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.explore-preview-result-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+:root[data-theme="dark"] .explore-next-secondary,
+:root[data-theme="dark"] .explore-preview-guide > * {
+  background: rgba(15, 23, 42, 0.58);
+}
+
+.explore-session-recovery {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(220px, 0.35fr);
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+  padding: 1.2rem;
+  border: 1px solid rgba(245, 158, 11, 0.3);
+  border-left: 4px solid #f59e0b;
+  border-radius: 10px;
+  background: rgba(245, 158, 11, 0.07);
+}
+
+.explore-session-recovery h2 {
+  margin: 0.6rem 0 0.4rem;
+  color: var(--text-primary);
+  font-size: 1.2rem;
+  line-height: 1.25;
+}
+
+.explore-session-recovery p {
+  max-width: 68ch;
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.92rem;
+  line-height: 1.55;
+}
+
+.explore-session-recovery-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  align-self: center;
+}
+
+.explore-session-recovery-error {
+  margin-top: 0.6rem !important;
+  color: var(--error) !important;
 }
 
 /* Discovery card */
@@ -3656,8 +3930,12 @@ details[open] .summary-arrow {
 
   .page-nav .nav-link {
     flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
     text-align: center;
     flex-shrink: 1;
+    white-space: nowrap;
   }
 
   .page-nav::-webkit-scrollbar {
@@ -3740,6 +4018,24 @@ details[open] .summary-arrow {
   .overview-report-actions .primary-button {
     width: 100%;
     white-space: normal;
+  }
+
+  .explore-next-steps {
+    grid-template-columns: 1fr;
+    padding: 1.1rem;
+  }
+
+  .explore-session-recovery {
+    grid-template-columns: 1fr;
+  }
+
+  .explore-next-actions {
+    width: 100%;
+  }
+
+  .explore-preview-guide,
+  .explore-preview-result-list {
+    grid-template-columns: 1fr;
   }
 
   .status-section {
@@ -9617,6 +9913,7 @@ details[open] .summary-arrow {
   flex-direction: column;
   justify-content: center;
   gap: 1.6rem;
+  min-width: 0;
 }
 
 .landing-home-copy h1 {
@@ -9626,6 +9923,35 @@ details[open] .summary-arrow {
   line-height: 1;
   letter-spacing: 0;
   color: var(--text-primary);
+}
+
+.landing-home-subtitle {
+  max-width: 62ch;
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 1.08rem;
+  line-height: 1.7;
+  overflow-wrap: anywhere;
+}
+
+.landing-home-proof {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.landing-home-proof span {
+  display: inline-flex;
+  align-items: center;
+  max-width: 100%;
+  min-height: 2rem;
+  padding: 0.35rem 0.7rem;
+  border: 1px solid rgba(37, 99, 235, 0.2);
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.06);
+  color: var(--text-primary);
+  font-size: 0.82rem;
+  font-weight: 700;
 }
 
 .landing-home-explainer {
@@ -9669,6 +9995,7 @@ details[open] .summary-arrow {
   box-shadow: 0 10px 26px rgba(15, 23, 42, 0.08);
   position: relative;
   overflow: hidden;
+  min-width: 0;
 }
 
 .landing-home-start-panel::before {
@@ -9686,6 +10013,12 @@ details[open] .summary-arrow {
   font-size: 1.05rem;
   line-height: 1.25;
   letter-spacing: 0;
+}
+
+.landing-home-start-panel .landing-primary-button,
+.landing-home-start-panel .landing-secondary-button {
+  width: 100%;
+  min-height: 2.75rem;
 }
 
 .landing-start-actions {
@@ -9718,6 +10051,82 @@ details[open] .summary-arrow {
   background: rgba(59, 130, 246, 0.08);
   border-color: rgba(59, 130, 246, 0.32);
   transform: translateY(-1px);
+}
+
+.landing-start-note,
+.landing-start-error,
+.landing-start-help {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.84rem;
+  line-height: 1.55;
+}
+
+.landing-start-error {
+  color: var(--error);
+}
+
+.landing-start-help a {
+  color: var(--accent-blue);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.landing-upload-success,
+.landing-preview-results {
+  display: grid;
+  gap: 0.25rem;
+  margin: 0;
+  padding: 0.75rem;
+  border: 1px solid rgba(16, 185, 129, 0.22);
+  border-radius: 8px;
+  background: rgba(16, 185, 129, 0.06);
+  color: var(--text-secondary);
+  font-size: 0.84rem;
+  line-height: 1.45;
+}
+
+.landing-upload-success strong,
+.landing-preview-results strong {
+  color: var(--text-primary);
+  font-size: 0.9rem;
+}
+
+.landing-preview-results {
+  border-color: rgba(59, 130, 246, 0.22);
+  background: rgba(59, 130, 246, 0.06);
+}
+
+.landing-preview-results span {
+  color: var(--text-primary);
+}
+
+.landing-home-steps {
+  display: grid;
+  gap: 0.55rem;
+  margin: 0;
+  padding: 0.75rem 0 0 1.35rem;
+  border-top: 1px solid var(--border-color);
+  color: var(--text-primary);
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.landing-provider-guides {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.landing-provider-guides a {
+  border: 1px solid rgba(59, 130, 246, 0.18);
+  border-radius: 999px;
+  padding: 0.25rem 0.55rem;
+  background: rgba(59, 130, 246, 0.06);
+  color: var(--accent-blue);
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-decoration: none;
 }
 
 :root[data-theme="dark"] .landing-home-intro {
@@ -9754,17 +10163,36 @@ details[open] .summary-arrow {
   }
 
   .landing-home-intro {
+    gap: 1.1rem;
     padding: 1.25rem;
+  }
+
+  .landing-home-copy {
+    display: contents;
   }
 
   .landing-home-start-panel {
     border-radius: 8px;
     padding: 1.1rem;
+    order: 3;
   }
 
   .landing-home-copy h1 {
     max-width: none;
-    font-size: clamp(2.2rem, 11vw, 3.2rem);
+    font-size: clamp(2rem, 10vw, 2.85rem);
+    order: 1;
+  }
+
+  .landing-home-subtitle {
+    order: 2;
+  }
+
+  .landing-home-proof {
+    order: 4;
+  }
+
+  .landing-home-explainer {
+    order: 5;
   }
 
   .landing-home-explainer p {
@@ -11479,6 +11907,44 @@ details[open] .summary-arrow {
   margin: 0 0 1.25rem;
 }
 
+.srb-evidence {
+  display: grid;
+  gap: 0.6rem;
+  margin-top: 0.5rem;
+  padding: 0.85rem;
+  border: 1px solid rgba(59, 130, 246, 0.18);
+  border-radius: 8px;
+  background: rgba(59, 130, 246, 0.05);
+}
+
+.srb-evidence strong {
+  color: var(--text-primary);
+  font-size: 0.88rem;
+}
+
+.srb-evidence-items {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.srb-evidence-items span {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.65rem;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 999px;
+  padding: 0.25rem 0.55rem;
+  background: rgba(255, 255, 255, 0.5);
+  color: var(--text-secondary);
+  font-size: 0.74rem;
+  font-weight: 700;
+}
+
+:root[data-theme="dark"] .srb-evidence-items span {
+  background: rgba(15, 23, 42, 0.58);
+}
+
 .srb-no-match {
   font-size: 0.9rem;
   color: var(--text-secondary);
@@ -12247,3 +12713,92 @@ a.heatmap-chip:hover {
   text-align: center;
 }
 
+/* Raw DNA guide */
+.guide-page {
+  max-width: 980px;
+  overflow-x: hidden;
+}
+
+.guide-hero {
+  display: grid;
+  gap: 1rem;
+  min-width: 0;
+  padding: 2rem;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--surface-bg);
+}
+
+.guide-eyebrow {
+  color: var(--accent-blue);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.guide-hero h1 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: clamp(2.1rem, 5vw, 3.7rem);
+  line-height: 1;
+  letter-spacing: 0;
+  overflow-wrap: anywhere;
+}
+
+.guide-hero p {
+  max-width: 68ch;
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 1.05rem;
+  line-height: 1.7;
+  overflow-wrap: anywhere;
+}
+
+.guide-hero .landing-primary-button {
+  width: fit-content;
+  max-width: 100%;
+  white-space: normal;
+  text-align: center;
+}
+
+.guide-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.guide-grid article,
+.guide-provider-section {
+  padding: 1.25rem;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--surface-bg);
+}
+
+.guide-grid h2,
+.guide-provider-section h2 {
+  margin: 0 0 0.6rem;
+  color: var(--text-primary);
+  font-size: 1.1rem;
+}
+
+.guide-grid p {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.65;
+}
+
+@media (max-width: 768px) {
+  .guide-hero {
+    padding: 1.25rem;
+  }
+
+  .guide-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .guide-hero .landing-primary-button {
+    width: 100%;
+  }
+}

--- a/app/landing-client.tsx
+++ b/app/landing-client.tsx
@@ -7,7 +7,19 @@ import { useGenotype } from "./components/UserDataUpload";
 import { useResults } from "./components/ResultsContext";
 import { useCustomization, type UserCustomization } from "./components/CustomizationContext";
 import { ResultsManager } from "@/lib/results-manager";
-import { trackGetStartedClicked, trackSampleDataStarted, trackSampleDataLoaded, trackSampleDataFailed } from "@/lib/analytics";
+import { runAllAnalysisOnboarding, type OnboardingRunAllProgress } from "@/lib/run-all-onboarding";
+import { selectAhaPreviewResults } from "@/lib/preview-insights";
+import {
+  trackFirstResultViewed,
+  trackGetStartedClicked,
+  trackProviderGuideClicked,
+  trackQuickPreviewCompleted,
+  trackQuickPreviewFailed,
+  trackQuickPreviewStarted,
+  trackSampleDataStarted,
+  trackSampleDataLoaded,
+  trackSampleDataFailed,
+} from "@/lib/analytics";
 
 const SAMPLE_RESULTS_FILE_NAME = "monadic_dna_explorer_results_2026-05-19.tsv";
 const SAMPLE_CUSTOMIZATION_PASSWORD = "sample-data";
@@ -26,6 +38,7 @@ const SAMPLE_CUSTOMIZATION: UserCustomization = {
 };
 
 type SampleLoadStatus = "idle" | "downloading" | "loading" | "loaded" | "error";
+type PreviewStatus = "idle" | "running" | "complete" | "error";
 
 function formatBytes(bytes: number): string {
   if (!bytes) return "0 KB";
@@ -68,13 +81,62 @@ const featureCopy = [
 
 export default function LandingClient() {
   const router = useRouter();
-  const { error } = useGenotype();
-  const { addResultsBatch, clearResults, savedResults } = useResults();
+  const { error, isUploaded, genotypeData, originalFileName, originalFileSize, detectedFormat } = useGenotype();
+  const { addResultsBatch, clearResults, savedResults, hasResult } = useResults();
   const { saveCustomization, status: customizationStatus } = useCustomization();
   const [sampleStatus, setSampleStatus] = useState<SampleLoadStatus>("idle");
   const [sampleError, setSampleError] = useState<string | null>(null);
   const [sampleBytes, setSampleBytes] = useState(0);
   const [sampleTotalBytes, setSampleTotalBytes] = useState(0);
+  const [previewStatus, setPreviewStatus] = useState<PreviewStatus>("idle");
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [previewProgress, setPreviewProgress] = useState<OnboardingRunAllProgress | null>(null);
+  const [previewTraitNames, setPreviewTraitNames] = useState<string[]>([]);
+
+  const openDNAUpload = () => {
+    trackGetStartedClicked("home_upload_raw_dna");
+    window.dispatchEvent(new CustomEvent("openDNAUpload", { detail: { source: "home_upload_raw_dna" } }));
+  };
+
+  const startFullAnalysis = () => {
+    trackGetStartedClicked("home_analyze_uploaded_dna");
+    window.dispatchEvent(new CustomEvent("startRunAllAnalysis"));
+  };
+
+  const runQuickPreview = async () => {
+    if (!genotypeData || previewStatus === "running") return;
+
+    trackQuickPreviewStarted("home");
+    setPreviewStatus("running");
+    setPreviewError(null);
+    setPreviewTraitNames([]);
+
+    try {
+      const results = await runAllAnalysisOnboarding(
+        genotypeData,
+        (progress) => setPreviewProgress(progress),
+        hasResult,
+        { maxResults: 1000 }
+      );
+
+      if (!results.length) {
+        throw new Error("No preview matches were found in the quick scan. You can still run the full catalog analysis.");
+      }
+
+      const curatedResults = selectAhaPreviewResults(results, 12);
+      await addResultsBatch(curatedResults);
+      const traitNames = curatedResults.slice(0, 3).map((result) => result.traitName);
+      setPreviewTraitNames(traitNames);
+      setPreviewStatus("complete");
+      trackQuickPreviewCompleted(curatedResults.length, "home");
+      trackFirstResultViewed("home_preview");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "The quick preview could not complete.";
+      setPreviewStatus("error");
+      setPreviewError(message);
+      trackQuickPreviewFailed(message, "home");
+    }
+  };
 
   const loadSampleData = async () => {
     if (savedResults.length > 0) {
@@ -156,50 +218,41 @@ export default function LandingClient() {
       ? "Parsing results…"
       : null;
 
+  const formatFileSize = (bytes: number | null) => {
+    if (!bytes) return null;
+    if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  };
+
+  const previewProgressText =
+    previewStatus === "running" && previewProgress
+      ? previewProgress.phase === "downloading"
+        ? "Preparing preview catalog..."
+        : previewProgress.phase === "analyzing"
+        ? `Scanning studies, ${previewProgress.matchCount} candidate matches found`
+        : previewProgress.message
+      : null;
+
   return (
     <main className="page landing-page landing-home-page">
-      <section className="landing-home-intro" style={{ display: 'block', padding: '2rem 2.5rem' }}>
+      <section className="landing-home-intro">
         <div className="landing-home-copy">
-          <h1 style={{ maxWidth: 'none' }}>Understand your DNA without giving it away.</h1>
+          <h1>Analyze your raw DNA file privately.</h1>
 
-          <p style={{ marginTop: '0.5rem', marginBottom: '1.5rem', fontSize: '1.05rem', color: 'var(--text-secondary)' }}>
-            Upload your DNA file or try it now with sample data, free.
+          <p className="landing-home-subtitle">
+            Upload a 23andMe, AncestryDNA, MyHeritage, FTDNA, LivingDNA, CSV, or TSV file. Your raw DNA file stays in your browser while the app matches variants against GWAS Catalog research.
           </p>
 
           {error && <p className="landing-upload-error">{error}</p>}
 
-          <div style={{ marginBottom: '2rem' }}>
-            <button
-              className="primary-button"
-              onClick={loadSampleData}
-              disabled={sampleStatus === "downloading" || sampleStatus === "loading"}
-              style={{ fontSize: '1rem', padding: '0.75rem 2rem' }}
-            >
-              {sampleLabel}
-            </button>
-            {sampleProgressText && (
-              <p style={{ marginTop: '0.5rem', fontSize: '0.82rem', color: 'var(--text-secondary)' }}>
-                {sampleProgressText}
-              </p>
-            )}
-            {sampleError && (
-              <p style={{ marginTop: '0.5rem', fontSize: '0.82rem', color: 'var(--error)' }}>{sampleError}</p>
-            )}
-            <p style={{ marginTop: '0.6rem', fontSize: '0.82rem', color: 'var(--text-secondary)' }}>
-              No DNA file needed. Your data never leaves your device.{' '}
-              <a
-                href={SCHEDULE_CALL_URL}
-                target="_blank"
-                rel="noreferrer"
-                style={{ color: 'var(--accent-blue)', textDecoration: 'none' }}
-                onClick={() => trackGetStartedClicked("schedule_video_call")}
-              >
-                Need help? Book a free call.
-              </a>
-            </p>
+          <div className="landing-home-proof" aria-label="Privacy and scientific safeguards">
+            <span>Local file processing</span>
+            <span>No DNA account required</span>
+            <span>GWAS evidence, effect sizes, and p-values</span>
+            <span>Educational use, not diagnosis</span>
           </div>
 
-          <div className="landing-home-explainer" aria-label="Monadic DNA Explorer features" style={{ maxWidth: 'none' }}>
+          <div className="landing-home-explainer" aria-label="Monadic DNA Explorer features">
             {featureCopy.map((item) => (
               <p key={item.label}>
                 <span>
@@ -221,6 +274,128 @@ export default function LandingClient() {
               </p>
             ))}
           </div>
+        </div>
+
+        <div className="landing-home-start-panel" aria-label="Start private DNA analysis">
+          <h2>Start with your raw DNA file</h2>
+
+          <div className="landing-start-actions">
+            {isUploaded ? (
+              <button
+                className="landing-primary-button"
+                onClick={savedResults.length > 0 || previewStatus === "complete" ? () => router.push("/explore") : runQuickPreview}
+                disabled={previewStatus === "running"}
+              >
+                {previewStatus === "running"
+                  ? "Finding preview results..."
+                  : savedResults.length > 0 || previewStatus === "complete"
+                  ? "Explore my results"
+                  : "Run quick preview"}
+              </button>
+            ) : (
+              <button
+                className="landing-primary-button"
+                onClick={openDNAUpload}
+              >
+                Upload raw DNA file
+              </button>
+            )}
+
+            <button
+              className="landing-secondary-button"
+              onClick={isUploaded ? startFullAnalysis : loadSampleData}
+              disabled={previewStatus === "running" || sampleStatus === "downloading" || sampleStatus === "loading"}
+            >
+              {isUploaded ? "Run full analysis" : sampleLabel}
+            </button>
+
+            {isUploaded && savedResults.length === 0 && (
+              <button
+                className="landing-secondary-button"
+                onClick={loadSampleData}
+                disabled={previewStatus === "running" || sampleStatus === "downloading" || sampleStatus === "loading"}
+              >
+                {sampleLabel}
+              </button>
+            )}
+
+            {sampleProgressText && (
+              <p className="landing-start-note">{sampleProgressText}</p>
+            )}
+            {previewProgressText && (
+              <p className="landing-start-note">{previewProgressText}</p>
+            )}
+            {sampleError && (
+              <p className="landing-start-error">{sampleError}</p>
+            )}
+            {previewError && (
+              <p className="landing-start-error">{previewError}</p>
+            )}
+          </div>
+
+          {isUploaded && genotypeData ? (
+            <div className="landing-upload-success" aria-label="Upload success">
+              <strong>File parsed successfully</strong>
+              <span>{genotypeData.size.toLocaleString()} variants loaded{detectedFormat ? ` from ${detectedFormat}` : ""}.</span>
+              {originalFileName && <span>{originalFileName}{formatFileSize(originalFileSize) ? `, ${formatFileSize(originalFileSize)}` : ""}</span>}
+              <span>Your raw DNA file stayed in this browser.</span>
+            </div>
+          ) : (
+            <p className="landing-start-note">
+              Nothing is uploaded to us. The file picker opens locally, and analysis runs in this browser.
+            </p>
+          )}
+
+          {previewTraitNames.length > 0 && (
+            <div className="landing-preview-results" aria-label="Preview result examples">
+              <strong>Preview results ready</strong>
+              {previewTraitNames.map((traitName) => (
+                <span key={traitName}>{traitName}</span>
+              ))}
+            </div>
+          )}
+
+          <ol className="landing-home-steps">
+            <li>Choose your raw DNA file.</li>
+            <li>Start with a quick local preview.</li>
+            <li>Explore results and ask DNA Chat questions.</li>
+          </ol>
+
+          <div className="landing-provider-guides" aria-label="Provider download guides">
+            {[
+              ["23andMe", "23andme"],
+              ["AncestryDNA", "ancestry"],
+              ["MyHeritage", "myheritage"],
+              ["FTDNA", "ftdna"],
+              ["LivingDNA", "livingdna"],
+            ].map(([label, provider]) => (
+              <a
+                key={provider}
+                href={`https://monadicdna.com/guide/${provider}`}
+                target="_blank"
+                rel="noreferrer"
+                onClick={() => trackProviderGuideClicked(provider, "home")}
+              >
+                {label}
+              </a>
+            ))}
+          </div>
+
+          <p className="landing-start-help">
+            Need help getting your raw DNA file?{" "}
+            <a
+              href={SCHEDULE_CALL_URL}
+              target="_blank"
+              rel="noreferrer"
+              onClick={() => trackGetStartedClicked("schedule_video_call")}
+            >
+              Book a free call
+            </a>
+            {" "}or use a provider guide above.{" "}
+            <Link href="/raw-dna-guide">
+              Share the raw DNA guide
+            </Link>.
+          </p>
         </div>
       </section>
     </main>

--- a/app/overview-report/page.tsx
+++ b/app/overview-report/page.tsx
@@ -40,8 +40,11 @@ export default function OverviewReportPage() {
   }, []);
 
   useEffect(() => {
-    trackOverviewReportViewed();
-  }, []);
+    trackOverviewReportViewed({
+      resultCount: savedResults.length,
+      hasResults: savedResults.length > 0,
+    });
+  }, [savedResults.length]);
 
 
   const hasPremiumAccess = hasActiveSubscription || hasPromoAccess;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,12 +5,12 @@ import Footer from "./components/Footer";
 import LandingClient from "./landing-client";
 
 export const metadata: Metadata = {
-  title: "Monadic DNA | Personal DNA insights with privacy, autonomy, and boundless curiosity",
-  description: "Private DNA insights from trusted genetic research. Learn from your DNA while your data remains private, protected, and entirely in your hands.",
-  keywords: ["GWAS", "genetics", "DNA analysis", "genome explorer", "genetic traits", "personal genomics", "23andMe", "AncestryDNA"],
+  title: "Private Raw DNA Analysis | Monadic DNA Explorer",
+  description: "Upload a raw DNA file from 23andMe, AncestryDNA, MyHeritage, FTDNA, LivingDNA, CSV, or TSV. Analyze genetic traits privately in your browser using GWAS Catalog research.",
+  keywords: ["raw DNA upload", "private DNA analysis", "secure DNA analysis", "GWAS", "genetics", "DNA analysis", "genome explorer", "genetic traits", "personal genomics", "23andMe", "AncestryDNA"],
   openGraph: {
-    title: "Monadic DNA | Personal DNA insights with privacy, autonomy, and boundless curiosity",
-    description: "Private DNA insights from trusted genetic research. Learn from your DNA while your data remains private, protected, and entirely in your hands.",
+    title: "Private Raw DNA Analysis | Monadic DNA Explorer",
+    description: "Upload a raw DNA file and analyze genetic traits privately in your browser using GWAS Catalog research.",
     type: "website",
     url: "https://explorer.monadicdna.com",
     siteName: "Monadic DNA Explorer",
@@ -26,8 +26,8 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "Monadic DNA | Personal DNA insights with privacy, autonomy, and boundless curiosity",
-    description: "Private DNA insights from trusted genetic research. Learn from your DNA while your data remains private, protected, and entirely in your hands.",
+    title: "Private Raw DNA Analysis | Monadic DNA Explorer",
+    description: "Upload a raw DNA file and analyze genetic traits privately in your browser using GWAS Catalog research.",
     images: ["/og-image.png"],
   },
 };
@@ -46,7 +46,7 @@ const websiteJsonLd = {
   "@type": "WebSite",
   "name": "Monadic DNA Explorer",
   "url": "https://explorer.monadicdna.com",
-  "description": "Private DNA insights from trusted genetic research.",
+  "description": "Private raw DNA analysis from trusted genetic research.",
   "potentialAction": {
     "@type": "SearchAction",
     "target": {

--- a/app/raw-dna-guide/page.tsx
+++ b/app/raw-dna-guide/page.tsx
@@ -1,0 +1,77 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import MenuBar from "../components/MenuBar";
+import Footer from "../components/Footer";
+
+export const metadata: Metadata = {
+  title: "What Raw DNA Analysis Can Tell You | Monadic DNA Explorer",
+  description: "A privacy-first guide to raw DNA files, GWAS associations, scientific caveats, and browser-local genetic analysis.",
+  keywords: ["raw DNA analysis", "private DNA analysis", "GWAS guide", "23andMe raw data", "AncestryDNA raw data"],
+};
+
+export default function RawDNAGuidePage() {
+  return (
+    <div className="app-container">
+      <MenuBar />
+      <main className="page guide-page">
+        <section className="guide-hero">
+          <span className="guide-eyebrow">Privacy-safe guide</span>
+          <h1>What raw DNA analysis can tell you</h1>
+          <p>
+            Raw DNA files from consumer tests contain genotype calls at many known variants.
+            Monadic DNA Explorer compares those variants with GWAS Catalog studies in your browser.
+          </p>
+          <Link className="landing-primary-button" href="/">
+            Analyze a raw DNA file
+          </Link>
+        </section>
+
+        <section className="guide-grid" aria-label="Raw DNA analysis guide">
+          <article>
+            <h2>What you can learn</h2>
+            <p>
+              GWAS findings can show associations between variants and traits such as metabolism,
+              sleep, physical traits, disease susceptibility, and medication response research.
+            </p>
+          </article>
+
+          <article>
+            <h2>How to read the science</h2>
+            <p>
+              Each finding should be read with its study, p-value, effect size, sample context,
+              population context, and replication status. Most effects are probabilistic and small.
+            </p>
+          </article>
+
+          <article>
+            <h2>Privacy model</h2>
+            <p>
+              The raw DNA file is parsed locally. Results are held in browser memory unless you
+              choose to export them. The app should never need a DNA account to analyze your file.
+            </p>
+          </article>
+
+          <article>
+            <h2>Limits</h2>
+            <p>
+              GWAS associations are educational research signals. They are not medical diagnosis,
+              ancestry assignment, or a complete picture of health risk.
+            </p>
+          </article>
+        </section>
+
+        <section className="guide-provider-section">
+          <h2>Download your raw file</h2>
+          <div className="landing-provider-guides">
+            <a href="https://monadicdna.com/guide/23andme">23andMe</a>
+            <a href="https://monadicdna.com/guide/ancestry">AncestryDNA</a>
+            <a href="https://monadicdna.com/guide/myheritage">MyHeritage</a>
+            <a href="https://monadicdna.com/guide/ftdna">FTDNA</a>
+            <a href="https://monadicdna.com/guide/livingdna">LivingDNA</a>
+          </div>
+        </section>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/app/study/[id]/page.tsx
+++ b/app/study/[id]/page.tsx
@@ -136,6 +136,10 @@ export default async function StudyDetailPage({ params }: { params: Promise<{ id
           pubmedId={study.pubmedid}
           mappedGene={study.mapped_gene}
           reportedTrait={study.disease_trait}
+          pValue={study.p_value}
+          pValueMlog={study.pvalue_mlog}
+          initialSampleSize={study.initial_sample_size}
+          replicationSampleSize={study.replication_sample_size}
         />
 
         {/* Study Details */}

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -25,7 +25,7 @@ declare global {
 function trackEvent(eventName: string, params?: Record<string, any>) {
   if (typeof window !== 'undefined' && window.gtag) {
     try {
-      window.gtag('event', eventName, params);
+      window.gtag('event', eventName, sanitizeAnalyticsParams(params));
     } catch (error) {
       console.warn('Analytics tracking failed:', error);
     }
@@ -128,6 +128,20 @@ function sanitizeErrorReason(reason?: string): string | undefined {
   return reason.slice(0, 120);
 }
 
+const SENSITIVE_ANALYTICS_KEYS = new Set<string>();
+
+function sanitizeAnalyticsParams(params?: Record<string, any>): Record<string, any> | undefined {
+  if (!params) return undefined;
+
+  const safeParams = Object.fromEntries(
+    Object.entries(params).filter(([key, value]) =>
+      value !== undefined && !SENSITIVE_ANALYTICS_KEYS.has(key)
+    )
+  );
+
+  return Object.keys(safeParams).length > 0 ? safeParams : undefined;
+}
+
 /**
  * User accepted terms and moved past initial modal
  */
@@ -190,7 +204,7 @@ export function trackOnboardingDismissed(step: string) {
 /**
  * User clicked one of the homepage Get Started actions
  */
-export function trackGetStartedClicked(action: 'onboarding_tour' | 'welcome_options' | 'try_dna_chat_directly' | 'instructional_video' | 'schedule_video_call' | 'restart_onboarding') {
+export function trackGetStartedClicked(action: 'onboarding_tour' | 'welcome_options' | 'try_dna_chat_directly' | 'instructional_video' | 'schedule_video_call' | 'restart_onboarding' | 'home_upload_raw_dna' | 'home_analyze_uploaded_dna') {
   trackEvent('get_started_clicked', {
     action,
   });
@@ -327,11 +341,32 @@ export function trackGenotypeFileUploadStarted(source: string = 'unknown') {
   });
 }
 
+export function trackUploadPickerOpened(source: string = 'unknown') {
+  trackEvent('upload_picker_opened', {
+    source,
+  });
+}
+
+export function trackGenotypeParseStarted(source: string = 'unknown', fileExtension?: string) {
+  trackEvent('genotype_parse_started', {
+    source,
+    file_extension: fileExtension,
+  });
+}
+
+export function trackGenotypeParseSucceeded(source: string = 'unknown', detectedFormat?: string, variantCount?: number) {
+  trackEvent('genotype_parse_succeeded', {
+    source,
+    detected_format: detectedFormat,
+    variant_count: variantCount,
+  });
+}
+
 export function trackGenotypeFileUploadFailed(source: string = 'unknown', reason?: string, fileExtension?: string) {
   trackEvent('genotype_file_upload_failed', {
     source,
     reason: sanitizeErrorReason(reason),
-    ...(fileExtension && { file_extension: fileExtension }),
+    file_extension: fileExtension,
   });
 }
 
@@ -340,13 +375,12 @@ export function trackGenotypeFileLoaded(fileSize: number, variantCount: number, 
     file_size_kb: Math.round(fileSize / 1024),
     variant_count: variantCount,
     source,
-    ...(detectedFormat && { detected_format: detectedFormat }),
-    ...(fileExtension && { file_extension: fileExtension }),
+    detected_format: detectedFormat,
+    file_extension: fileExtension,
   };
 
   trackEvent('genotype_file_loaded', metadata);
 
-  // Track as Lead event on Reddit (DNA upload is a lead generation action)
   const conversionId = `dna_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
   trackRedditEvent('Lead', {
     conversionId,
@@ -355,8 +389,7 @@ export function trackGenotypeFileLoaded(fileSize: number, variantCount: number, 
     conversion_id: conversionId,
   });
 
-  // Track as Lead event on X
-  trackXEvent('tw-r9lkr-rbtjs', { // Custom event - DNA File Upload
+  trackXEvent('tw-r9lkr-rbtjs', {
     conversion_id: conversionId,
   });
   trackXConversion('Lead', {
@@ -459,9 +492,45 @@ export function trackRunAllFailed(source: 'menu' | 'explore' | 'onboarding', rea
   });
 }
 
-export function trackLLMQuestionAsked(params?: { isFollowUp?: boolean }) {
+export function trackQuickPreviewStarted(source: 'home' | 'onboarding' = 'home') {
+  trackEvent('quick_preview_started', {
+    source,
+  });
+}
+
+export function trackQuickPreviewCompleted(resultCount: number, source: 'home' | 'onboarding' = 'home') {
+  trackEvent('quick_preview_completed', {
+    source,
+    result_count: resultCount,
+  });
+}
+
+export function trackQuickPreviewFailed(reason?: string, source: 'home' | 'onboarding' = 'home') {
+  trackEvent('quick_preview_failed', {
+    source,
+    reason: sanitizeErrorReason(reason),
+  });
+}
+
+export function trackFirstResultViewed(source: 'home_preview' | 'study' | 'results' = 'results') {
+  trackEvent('first_result_viewed', {
+    source,
+  });
+}
+
+export function trackProviderGuideClicked(provider: string, source: 'home' | 'upload' | 'study' = 'home') {
+  trackEvent('provider_guide_clicked', {
+    provider,
+    source,
+  });
+}
+
+export function trackLLMQuestionAsked(params?: { isFollowUp?: boolean; hasUploadedDna?: boolean; resultCount?: number; source?: 'chat' | 'research' | 'onboarding' }) {
   trackEvent('llm_question_asked', {
     is_follow_up: params?.isFollowUp ?? false,
+    has_uploaded_dna: params?.hasUploadedDna,
+    result_count: params?.resultCount,
+    source: params?.source,
   });
 }
 
@@ -489,8 +558,11 @@ export function trackAIConsentModalShown() {
   trackEvent('ai_consent_modal_shown');
 }
 
-export function trackOverviewReportViewed() {
-  trackEvent('overview_report_viewed');
+export function trackOverviewReportViewed(params?: { resultCount?: number; hasResults?: boolean }) {
+  trackEvent('overview_report_viewed', {
+    result_count: params?.resultCount,
+    has_results: params?.hasResults,
+  });
 }
 
 /**
@@ -531,6 +603,12 @@ export function trackReportOpenedInChat(reportType: 'health_insights' | 'healths
 
 export function trackExplorePageViewed() {
   trackEvent('explore_page_viewed');
+}
+
+export function trackExploreFollowupClicked(action: 'run_full_analysis' | 'ask_dna_chat' | 'preview_best_question' | 'personalize' | 'browse') {
+  trackEvent('explore_followup_clicked', {
+    action,
+  });
 }
 
 export function trackContinueInDNAChat(source: 'study_analysis') {

--- a/lib/evidence-labels.ts
+++ b/lib/evidence-labels.ts
@@ -1,0 +1,76 @@
+import type { SavedResult } from "./results-manager";
+
+function parsePValue(result: Pick<SavedResult, "pValue" | "pValueMlog">): number | null {
+  if (result.pValue) {
+    const normalized = result.pValue.replace(/\s/g, "").replace(/x10\^/i, "e");
+    const value = Number.parseFloat(normalized);
+    if (Number.isFinite(value) && value > 0) return value;
+  }
+
+  if (result.pValueMlog) {
+    const mlog = Number.parseFloat(result.pValueMlog);
+    if (Number.isFinite(mlog) && mlog > 0) return Math.pow(10, -mlog);
+  }
+
+  return null;
+}
+
+function parseLargestNumber(value?: string): number | null {
+  if (!value) return null;
+  const matches = value.match(/\d[\d,]*/g);
+  if (!matches?.length) return null;
+  const values = matches
+    .map((match) => Number.parseInt(match.replace(/,/g, ""), 10))
+    .filter((number) => Number.isFinite(number));
+  if (!values.length) return null;
+  return Math.max(...values);
+}
+
+export function getEvidenceBand(result: SavedResult): "strong" | "moderate" | "limited" {
+  const pValue = parsePValue(result);
+  const sampleSize = parseLargestNumber(result.sampleSize);
+  const hasReplication = !!result.replicationSampleSize?.trim();
+
+  if ((pValue !== null && pValue <= 5e-8) && (hasReplication || (sampleSize !== null && sampleSize >= 10000))) {
+    return "strong";
+  }
+
+  if ((pValue !== null && pValue <= 5e-8) || (sampleSize !== null && sampleSize >= 10000)) {
+    return "moderate";
+  }
+
+  return "limited";
+}
+
+export function getEvidenceLabel(result: SavedResult): string {
+  const band = getEvidenceBand(result);
+  if (band === "strong") return "Stronger GWAS evidence";
+  if (band === "moderate") return "Moderate GWAS evidence";
+  return "Limited context available";
+}
+
+export function getEvidenceDetails(result: SavedResult): string[] {
+  const details: string[] = [];
+  const pValue = parsePValue(result);
+
+  if (pValue !== null) {
+    details.push(pValue <= 5e-8 ? "Genome-wide significant p-value" : "Association p-value reported");
+  }
+
+  if (result.sampleSize) {
+    details.push(`Initial sample: ${result.sampleSize}`);
+  }
+
+  if (result.replicationSampleSize) {
+    details.push(`Replication sample: ${result.replicationSampleSize}`);
+  }
+
+  if (result.effectType === "beta") {
+    details.push("Beta effect, not an odds ratio");
+  } else {
+    details.push("Odds ratio is relative, not absolute risk");
+  }
+
+  details.push("Educational interpretation, not diagnosis");
+  return details;
+}

--- a/lib/preview-insights.ts
+++ b/lib/preview-insights.ts
@@ -1,0 +1,247 @@
+import type { SavedResult } from "./results-manager";
+
+type PreviewCategory =
+  | "body_composition"
+  | "cardiometabolic"
+  | "immune"
+  | "brain_behavior"
+  | "sleep_energy"
+  | "reproductive"
+  | "appearance"
+  | "medication"
+  | "other";
+
+type CategoryDefinition = {
+  id: PreviewCategory;
+  label: string;
+  keywords: string[];
+};
+
+export type PreviewInsight = {
+  themes: { label: string; count: number }[];
+  standout: SavedResult | null;
+  protectiveCount: number;
+  elevatedCount: number;
+  headline: string;
+};
+
+const CATEGORY_DEFINITIONS: CategoryDefinition[] = [
+  {
+    id: "body_composition",
+    label: "body composition",
+    keywords: ["body mass", "bmi", "weight", "obesity", "height", "adiposity", "waist", "lean mass", "fat mass"],
+  },
+  {
+    id: "cardiometabolic",
+    label: "cardiometabolic traits",
+    keywords: ["cholesterol", "lipid", "triglyceride", "glucose", "insulin", "diabetes", "blood pressure", "coronary", "heart"],
+  },
+  {
+    id: "immune",
+    label: "immune and inflammation",
+    keywords: ["immune", "inflammatory", "asthma", "allergy", "eczema", "psoriasis", "arthritis", "celiac", "crohn", "colitis"],
+  },
+  {
+    id: "brain_behavior",
+    label: "brain and behavior",
+    keywords: ["cognitive", "intelligence", "education", "neuroticism", "depression", "anxiety", "adhd", "risk taking", "alcohol", "smoking"],
+  },
+  {
+    id: "sleep_energy",
+    label: "sleep and energy",
+    keywords: ["sleep", "chronotype", "morning", "insomnia", "fatigue", "caffeine", "restless"],
+  },
+  {
+    id: "reproductive",
+    label: "hormonal and reproductive traits",
+    keywords: ["endometriosis", "menopause", "menarche", "testosterone", "estrogen", "fertility", "reproductive", "puberty"],
+  },
+  {
+    id: "appearance",
+    label: "visible traits",
+    keywords: ["hair", "skin", "eye color", "freckle", "baldness", "pigmentation", "facial", "tooth"],
+  },
+  {
+    id: "medication",
+    label: "medication response",
+    keywords: ["drug", "medication", "statin", "warfarin", "metformin", "response", "adverse", "pharmacogen"],
+  },
+];
+
+const GENERIC_TRAIT_WORDS = new Set([
+  "stage",
+  "type",
+  "disease",
+  "disorder",
+  "condition",
+  "measurement",
+  "self",
+  "reported",
+  "adjusted",
+  "male",
+  "female",
+  "men",
+  "women",
+]);
+
+function normalizeTraitName(traitName: string): string {
+  return traitName
+    .toLowerCase()
+    .replace(/\([^)]*\)/g, " ")
+    .replace(/[^a-z0-9]+/g, " ")
+    .split(/\s+/)
+    .filter((word) => word.length > 2 && !GENERIC_TRAIT_WORDS.has(word))
+    .join(" ")
+    .trim();
+}
+
+export function getPreviewCategory(result: SavedResult): { id: PreviewCategory; label: string } {
+  const text = `${result.traitName} ${result.studyTitle} ${result.mappedGene || ""}`.toLowerCase();
+  const match = CATEGORY_DEFINITIONS.find((category) =>
+    category.keywords.some((keyword) => text.includes(keyword))
+  );
+
+  if (!match) return { id: "other", label: "other traits" };
+  return { id: match.id, label: match.label };
+}
+
+export function formatPreviewEffect(result: SavedResult, compact = false): string {
+  if (result.effectType === "beta") {
+    return `β=${result.riskScore >= 0 ? "+" : ""}${result.riskScore.toFixed(3)}`;
+  }
+
+  if (result.riskLevel === "neutral") return "baseline";
+  if (compact) return `${result.riskScore.toFixed(2)}x ${result.riskLevel === "increased" ? "↑" : "↓"}`;
+  return `${result.riskScore.toFixed(2)}x ${result.riskLevel === "increased" ? "higher relative odds" : "lower relative odds"}`;
+}
+
+function parseNumeric(value?: string): number | null {
+  if (!value) return null;
+  const parsed = Number.parseFloat(value.replace(/,/g, ""));
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function effectMagnitude(result: SavedResult): number {
+  if (result.effectType === "beta") return Math.min(Math.abs(result.riskScore) * 4, 2.5);
+  if (result.riskScore <= 0 || result.riskScore > 50) return 0;
+  return Math.min(Math.abs(Math.log(result.riskScore)), 2.5);
+}
+
+function evidenceScore(result: SavedResult): number {
+  const mlog = parseNumeric(result.pValueMlog);
+  const sampleText = `${result.sampleSize || ""} ${result.replicationSampleSize || ""}`;
+  const sampleNumbers = sampleText.match(/\d[\d,]*/g)?.map((value) => Number.parseInt(value.replace(/,/g, ""), 10)) || [];
+  const largestSample = sampleNumbers.length ? Math.max(...sampleNumbers) : 0;
+
+  let score = 0;
+  if (mlog !== null) score += Math.min(mlog / 10, 1.5);
+  if (largestSample >= 100000) score += 1;
+  else if (largestSample >= 10000) score += 0.6;
+  if (result.replicationSampleSize) score += 0.4;
+  return score;
+}
+
+function interestScore(result: SavedResult): number {
+  const category = getPreviewCategory(result).id;
+  const categoryBoost =
+    category === "other" ? 0 :
+    category === "appearance" ? 0.25 :
+    category === "cardiometabolic" || category === "immune" || category === "medication" ? 1 :
+    0.75;
+  return effectMagnitude(result) + evidenceScore(result) + categoryBoost;
+}
+
+function previewCategoryLimit(category: PreviewCategory): number {
+  if (category === "appearance") return 3;
+  if (category === "other") return 2;
+  return 3;
+}
+
+const CATEGORY_DISPLAY_PRIORITY: Record<PreviewCategory, number> = {
+  cardiometabolic: 0,
+  medication: 1,
+  immune: 2,
+  sleep_energy: 3,
+  reproductive: 4,
+  brain_behavior: 5,
+  body_composition: 6,
+  appearance: 7,
+  other: 8,
+};
+
+function orderPreviewResultsForDisplay(results: SavedResult[]): SavedResult[] {
+  return [...results].sort((a, b) => {
+    const categoryDiff = CATEGORY_DISPLAY_PRIORITY[getPreviewCategory(a).id] - CATEGORY_DISPLAY_PRIORITY[getPreviewCategory(b).id];
+    if (categoryDiff !== 0) return categoryDiff;
+    return interestScore(b) - interestScore(a);
+  });
+}
+
+export function selectAhaPreviewResults(results: SavedResult[], limit = 12): SavedResult[] {
+  const sorted = [...results].sort((a, b) => interestScore(b) - interestScore(a));
+  const selected: SavedResult[] = [];
+  const seenTraits = new Set<string>();
+  const categoryCounts = new Map<PreviewCategory, number>();
+
+  for (const result of sorted) {
+    const normalized = normalizeTraitName(result.traitName);
+    if (normalized && seenTraits.has(normalized)) continue;
+
+    const category = getPreviewCategory(result).id;
+    const categoryLimit = previewCategoryLimit(category);
+    if ((categoryCounts.get(category) || 0) >= categoryLimit) continue;
+
+    selected.push(result);
+    if (normalized) seenTraits.add(normalized);
+    categoryCounts.set(category, (categoryCounts.get(category) || 0) + 1);
+    if (selected.length >= limit) break;
+  }
+
+  if (selected.length < limit) {
+    for (const result of sorted) {
+      if (selected.some((item) => item.studyId === result.studyId)) continue;
+      const normalized = normalizeTraitName(result.traitName);
+      if (normalized && seenTraits.has(normalized)) continue;
+
+      const category = getPreviewCategory(result).id;
+      if ((categoryCounts.get(category) || 0) >= previewCategoryLimit(category)) continue;
+
+      selected.push(result);
+      if (normalized) seenTraits.add(normalized);
+      categoryCounts.set(category, (categoryCounts.get(category) || 0) + 1);
+      if (selected.length >= limit) break;
+    }
+  }
+
+  return orderPreviewResultsForDisplay(selected);
+}
+
+export function buildPreviewInsight(results: SavedResult[]): PreviewInsight {
+  const categoryCounts = new Map<string, number>();
+  for (const result of results) {
+    const category = getPreviewCategory(result).label;
+    categoryCounts.set(category, (categoryCounts.get(category) || 0) + 1);
+  }
+
+  const themes = [...categoryCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 3)
+    .map(([label, count]) => ({ label, count }));
+
+  const standout = [...results]
+    .filter((result) => result.riskLevel !== "neutral")
+    .sort((a, b) => interestScore(b) - interestScore(a))[0] || results[0] || null;
+
+  const protectiveCount = results.filter((result) => result.riskLevel === "decreased").length;
+  const elevatedCount = results.filter((result) => result.riskLevel === "increased").length;
+
+  return {
+    themes,
+    standout,
+    protectiveCount,
+    elevatedCount,
+    headline: themes.length > 0
+      ? `Your first matches point to ${themes.map((theme) => theme.label).join(", ")}.`
+      : "Your first matches are ready to explore.",
+  };
+}

--- a/lib/run-all-onboarding.ts
+++ b/lib/run-all-onboarding.ts
@@ -17,7 +17,8 @@ const ONBOARDING_CATALOG_URL =
 export async function runAllAnalysisOnboarding(
   genotypeData: Map<string, string>,
   onProgress: (progress: OnboardingRunAllProgress) => void,
-  hasResult: (studyId: number) => boolean
+  hasResult: (studyId: number) => boolean,
+  options: { maxResults?: number } = {}
 ): Promise<SavedResult[]> {
   const startTime = Date.now();
 
@@ -120,6 +121,10 @@ export async function runAllAnalysisOnboarding(
   const orBetaIdx = colMap.or_or_beta;
   const ciTextIdx = colMap.ci_text;
   const mappedGeneIdx = colMap.mapped_gene;
+  const pValueIdx = colMap.p_value;
+  const pValueMlogIdx = colMap.pvalue_mlog;
+  const sampleSizeIdx = colMap.initial_sample_size;
+  const replicationSampleSizeIdx = colMap.replication_sample_size;
 
   if (
     idIdx === undefined ||
@@ -244,9 +249,24 @@ export async function runAllAnalysisOnboarding(
           riskLevel,
           matchedSnp: riskSnpId,
           analysisDate: new Date().toISOString(),
+          pValue: pValueIdx !== undefined ? cols[pValueIdx] || undefined : undefined,
+          pValueMlog: pValueMlogIdx !== undefined ? cols[pValueMlogIdx] || undefined : undefined,
           mappedGene: cols[mappedGeneIdx] || undefined,
+          sampleSize: sampleSizeIdx !== undefined ? cols[sampleSizeIdx] || undefined : undefined,
+          replicationSampleSize: replicationSampleSizeIdx !== undefined ? cols[replicationSampleSizeIdx] || undefined : undefined,
         });
         matchCount++;
+        if (options.maxResults && results.length >= options.maxResults) {
+          emitProgress({
+            phase: "complete",
+            loaded: processedStudies,
+            total: processedStudies,
+            processedStudies,
+            matchCount,
+            message: "Preview analysis complete.",
+          });
+          return results;
+        }
       }
     }
 
@@ -311,7 +331,11 @@ export async function runAllAnalysisOnboarding(
             riskLevel,
             matchedSnp: riskSnpId,
             analysisDate: new Date().toISOString(),
+            pValue: pValueIdx !== undefined ? cols[pValueIdx] || undefined : undefined,
+            pValueMlog: pValueMlogIdx !== undefined ? cols[pValueMlogIdx] || undefined : undefined,
             mappedGene: cols[mappedGeneIdx] || undefined,
+            sampleSize: sampleSizeIdx !== undefined ? cols[sampleSizeIdx] || undefined : undefined,
+            replicationSampleSize: replicationSampleSizeIdx !== undefined ? cols[replicationSampleSizeIdx] || undefined : undefined,
           });
           matchCount++;
         }

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Redesigns the landing page experience and adds a quick DNA preview flow so users get meaningful results immediately after uploading a file, without waiting for a full catalog analysis.

## Changes

### Quick preview flow
- After uploading a raw DNA file, users can run a "quick preview" that scans a subset of the catalog and surfaces up to 12 curated results.
- `lib/preview-insights.ts`: new module that selects high-signal "aha" results from a batch of matches using effect size and evidence quality.
- `lib/evidence-labels.ts`: shared labels and helpers for GWAS evidence tiers used across result display.
- Progress feedback is shown inline on the landing page during the scan.

### Landing page redesign
- `app/landing-client.tsx`: restructured layout with a clearer call-to-action panel; buttons adapt based on upload state and preview status (upload, run preview, explore results, run full analysis, or try sample data).
- `app/globals.css`: new landing-specific CSS classes for the intro section, proof bar, explainer, and start panel.

### New raw DNA guide page
- `app/raw-dna-guide/page.tsx`: static informational page explaining how to export raw DNA files from 23andMe, AncestryDNA, MyHeritage, FTDNA, and LivingDNA.

### Analytics
- `lib/analytics.ts`: new tracking events for the preview funnel (`trackQuickPreviewStarted`, `trackQuickPreviewCompleted`, `trackQuickPreviewFailed`, `trackFirstResultViewed`, `trackGetStartedClicked`, `trackProviderGuideClicked`, `trackSampleDataStarted`, `trackSampleDataLoaded`, `trackSampleDataFailed`).
